### PR TITLE
Feature: Hide hash symbol in tag names in Nav Panel

### DIFF
--- a/src/navPanel.ts
+++ b/src/navPanel.ts
@@ -56,13 +56,14 @@ export async function updateNavPanel(panel: string, tagsLines: TagLine[], tagCou
   }
   // Build the list of current note tags
   const noteTagsHTML = tagsLines.map((tag) => {
+    const displayTag = hidePrefix ? tag.tag.replace(tagPrefix, '') : tag.tag;
     let indexText = '';
     if (tag.count > 1) {
-      indexText = `(${tag.index+1}/${tag.count})`;
+      indexText = `<span>(${tag.index+1}/${tag.count})</span>`;
     }
     return `
       <a class="itags-nav-noteTag" href="#" data-tag="${tag.tag}" data-line="${tag.lines[tag.index]}">
-      ${tag.tag} ${indexText}
+      ${displayTag} ${indexText}
       </a><br/>
     `;
   }).join('');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -476,7 +476,7 @@ export async function registerSettings(): Promise<void> {
       section: 'itags',
       public: true,
       label: 'Navigation: Hide tag prefix',
-      description: 'Hide the tag prefix (e.g., #) in the navigation panel.',
+      description: 'Hides the configured tag prefix (default: #) from tag names in the navigation panel.',
     },
     'itags.navPanelStyle': {
       value: '',


### PR DESCRIPTION
Hello!

I'd like to suggest a new feature: add a setting to hide the hash symbol in tag names within the Navigation Panel's tag tree, and wrap tag counts in span tags. This would make it easier to visually scan tag names, and tag counts could be styled with lower contrast. The main visual focus would then be on tag names themselves.
