### PR TITLE
make-auto-open-search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -799,6 +799,12 @@ joplin.plugins.register({
           displayInNote: 'false'
           // Don't preserve existing options - let it use global settings
         };
+        const panelState = await joplin.views.panels.visible(searchPanel);
+        if (!panelState) {
+          await joplin.views.panels.show(searchPanel);
+          await registerSearchPanel(searchPanel);
+          await focusSearchPanel(searchPanel);
+        }
         await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
         await updatePanelSettings(searchPanel, searchParams); // Update panel to reflect global settings
         const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);

--- a/src/navPanel.ts
+++ b/src/navPanel.ts
@@ -159,10 +159,11 @@ function buildTreeHTML(
 
     const fullTag = parentTag ? `${parentTag}/${tag}` : tag;
     const tagName = hidePrefix ? fullTag.replace(tagPrefix, '') : fullTag;
-    const indentStyle = `style="padding-left: ${(level +1) * 5}px;"`;
+    const indentStyle = `style="padding-left: ${level > 0 ? 31 : 18}px;"`;
+    const detailsStyle = `style="padding-left: ${level > 0 ? 18 : 5}px;"`;
 
     if (Object.keys(children).length > 0) {
-      html += `<details ${indentStyle}><summary><a href="#" class="itags-nav-globalTag" data-tag="${fullTag}" style="padding-left: 0px;">${tagName} <span>(${count})</span></a></summary>${buildTreeHTML(children, fullTag, sortBy, hidePrefix, tagPrefix, level + 1)}</details>`;
+      html += `<details ${detailsStyle}><summary><a href="#" class="itags-nav-globalTag" data-tag="${fullTag}" style="padding-left: 0px;">${tagName} <span>(${count})</span></a></summary>${buildTreeHTML(children, fullTag, sortBy, hidePrefix, tagPrefix, level + 1)}</details>`;
     } else {
       html += `<a href="#" class="itags-nav-globalTag" data-tag="${fullTag}" ${indentStyle}>${tagName} <span>(${count})</span></a><br/>`;
     }


### PR DESCRIPTION
Hello!
Moved from another PR:
1) Auto open hidden search panel by tag click
2) Fixes for tag vertical alignment. I checked for several font style and size, seems it is ok. It has some dependence of spacing on font size, but vertical alignment is ok, and marker is always under first letter.

<img width="338"  alt="image" src="https://github.com/user-attachments/assets/ec8a7e44-e2db-4e3d-920a-7e9e099c8a2f" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/16a06c20-acec-4ae6-b5ee-635e5dce8748" />
<img width="356" alt="Monospace" src="https://github.com/user-attachments/assets/da4af4d6-5da7-4716-bef2-c00a81019699" />

