### PR TITLE
feat: add CNF query mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For video tutorials, see the [Demos](#demos) section or the [full playlist](http
 This plugin adds inline tag support (such as #inline-tag) to [Joplin](https://joplinapp.org) in six ways:
 
 1. It adds a panel for searching and viewing tagged paragraphs across all your notes. ([video](https://www.youtube.com/watch?v=im0zjQFoXb0))
-    - **Search queries**: Search tags using logical operators (AND, OR, NOT), and using free text in the note, title, or notebook name / path.
+    - **Search queries**: Search tags using logical operators (AND, OR, NOT), and using free text in the note, title, or notebook name / path. Right-click in the query area to toggle between OR-of-ANDs (default) and AND-of-ORs modes.
     - **Save search queries** in notes and sync them across device. ([video](https://www.youtube.com/watch?v=GuzCwYxyYZ0), [tips](#saved-queries))
     - **Sort results by tags** such as priorities, dates, colors, or any other tag. Right-click a tag to sort by it or add it to a multi-key sort. ([video](https://www.youtube.com/watch?v=HvunHOc2zlM), [tips](#saved-queries))
     - **Tag-by-notes:** Search for links or [[wikilinks]] to notes (including backlinks to the current note).
@@ -294,8 +294,8 @@ Saved queries allow you to store search configurations in notes and reuse them a
 #### Core properties
 
 - **`query`**: Array of search terms (tags, notes, ranges)
-  - Outer array represents OR groups
-  - Inner arrays represent AND groups within each OR group
+  - In DNF mode (default): outer array represents OR groups, inner arrays represent AND groups
+  - In CNF mode: outer array represents AND groups, inner arrays represent OR groups
   - Each tag term has:
     - `tag`: The search term (tag, note link, or text)
     - `negated`: Boolean indicating whether to exclude this term
@@ -306,6 +306,9 @@ Saved queries allow you to store search configurations in notes and reuse them a
   - Each range term has:
     - `minValue`
     - `maxValue`
+- **`mode`**: Query interpretation mode (optional, defaults to `"dnf"`)
+  - `"dnf"`: OR-of-ANDs — results match any group, where each group requires all its tags (default)
+  - `"cnf"`: AND-of-ORs — results match all groups, where each group requires any of its tags
 - **`filter`**: String for additional text filtering within results
 - **`displayInNote`**: Display mode when viewing in notes
   - `"false"`: Do not show results
@@ -375,7 +378,7 @@ Saved queries allow you to store search configurations in notes and reuse them a
 }
 ```
 
-This example searches for paragraphs that have both `#artist` AND `#album` tags, OR paragraphs with `#single` tag, then filters results containing "rock" anywhere in the text, and displays them in a table sorted by year (ascending) then by artist (descending). The `country` column header is renamed to "Country of Origin".
+This example uses the default DNF mode to search for paragraphs that have both `#artist` AND `#album` tags, OR paragraphs with `#single` tag, then filters results containing "rock" anywhere in the text, and displays them in a table sorted by year (ascending) then by artist (descending). The `country` column header is renamed to "Country of Origin".
 
 </details>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ joplin.plugins.register({
       await updatePanelTagData(searchPanel, DatabaseManager.getDatabase());
 
       // Update search results
-      const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+      const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
       lastSearchResults = results; // Cache the results
       await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
     }, 1000);
@@ -172,7 +172,7 @@ joplin.plugins.register({
       await updatePanelNoteData(searchPanel, DatabaseManager.getDatabase());
 
       // Update search results
-      const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+      const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
       lastSearchResults = results; // Cache the results
       await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
 
@@ -251,7 +251,7 @@ joplin.plugins.register({
 
       if (searchParams.query.flatMap(x => x).some(x => x.externalId == 'current')) {
         // Update search results
-        const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+        const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
         lastSearchResults = results; // Cache the results
         await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
       }
@@ -298,7 +298,7 @@ joplin.plugins.register({
           await focusSearchPanel(searchPanel);
           await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
           await updatePanelSettings(searchPanel, searchParams);
-          const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+          const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
           await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
         }
@@ -364,7 +364,7 @@ joplin.plugins.register({
           }
           await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
           await updatePanelSettings(searchPanel, searchParams);
-          const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+          const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
           await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
         } catch (error) {
@@ -908,7 +908,7 @@ joplin.plugins.register({
           await focusSearchPanel(searchPanel);
           await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
           await updatePanelSettings(searchPanel, searchParams);
-          const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+          const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
           await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
         } else if (!wantVisible && isVisible) {
@@ -973,7 +973,7 @@ joplin.plugins.register({
         }
         await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
         await updatePanelSettings(searchPanel, searchParams); // Update panel to reflect global settings
-        const results = await runSearch(DatabaseManager.getDatabase(), searchParams.query, searchParams.options?.resultGrouping, searchParams.options);
+        const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
         lastSearchResults = results; // Cache the results
         await updatePanelResults(searchPanel, results, searchParams.query, searchParams.options);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { parseDateTag } from './parser';
 import { clearAllTagConversionData } from './tracker';
 import { clearObjectReferences, clearApiResponse, createManagedInterval, getMemoryManager } from './memory';
 
-let searchParams: QueryRecord = { query: [[]], filter: '', displayInNote: 'false' };
+let searchParams: QueryRecord = { query: [[]], filter: '', displayInNote: 'false', mode: 'dnf' };
 let currentTableColumns: string[] = [];
 let currentTableDefaultValues: { [key: string]: string } = {};
 let currentTableColumnSeparators: { [key: string]: TagSeparatorType } = {};
@@ -139,7 +139,7 @@ joplin.plugins.register({
         await joplin.views.panels.show(searchPanel);
         await registerSearchPanel(searchPanel);
         // Sync current query state so the panel can extend it
-        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
         await updatePanelSettings(searchPanel, searchParams);
       }
       await joplin.views.panels.postMessage(searchPanel, {
@@ -219,7 +219,7 @@ joplin.plugins.register({
       if (autoLoadQuery && savedQuery.query && savedQuery.query.length > 0 && savedQuery.query[0].length > 0) {
         // Updating this variable will ensure it's sent to the panel on initPanel
         searchParams = savedQuery;
-        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
         // Update panel settings to reflect the loaded query's options
         await updatePanelSettings(searchPanel, searchParams);
       }
@@ -296,7 +296,7 @@ joplin.plugins.register({
         if (!panelState) {
           await registerSearchPanel(searchPanel);
           await focusSearchPanel(searchPanel);
-          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
           await updatePanelSettings(searchPanel, searchParams);
           const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
@@ -326,7 +326,7 @@ joplin.plugins.register({
         if (savedQuery.query && savedQuery.query.length > 0 && savedQuery.query[0].length > 0) {
           // Updating this variable will ensure it's sent to the panel on initPanel
           searchParams = savedQuery;
-          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
           // Update panel settings to reflect the loaded query's options
           await updatePanelSettings(searchPanel, searchParams);
         }
@@ -354,7 +354,8 @@ joplin.plugins.register({
           searchParams = {
             query: [[{ tag: tagAtCursor, negated: false }]],
             filter: '',
-            displayInNote: 'false'
+            displayInNote: 'false',
+            mode: 'dnf',
           };
           const panelState = await joplin.views.panels.visible(searchPanel);
           if (!panelState) {
@@ -362,7 +363,7 @@ joplin.plugins.register({
             await registerSearchPanel(searchPanel);
             await focusSearchPanel(searchPanel);
           }
-          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
           await updatePanelSettings(searchPanel, searchParams);
           const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
@@ -906,7 +907,7 @@ joplin.plugins.register({
           await joplin.views.panels.show(searchPanel);
           await registerSearchPanel(searchPanel);
           await focusSearchPanel(searchPanel);
-          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+          await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
           await updatePanelSettings(searchPanel, searchParams);
           const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
           lastSearchResults = results;
@@ -962,7 +963,8 @@ joplin.plugins.register({
         searchParams = {
           query: [[{ tag: message.tag, negated: false }]],
           filter: '',
-          displayInNote: 'false'
+          displayInNote: 'false',
+          mode: 'dnf',
           // Don't preserve existing options - let it use global settings
         };
         const panelState = await joplin.views.panels.visible(searchPanel);
@@ -971,7 +973,7 @@ joplin.plugins.register({
           await registerSearchPanel(searchPanel);
           await focusSearchPanel(searchPanel);
         }
-        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter);
+        await updatePanelQuery(searchPanel, searchParams.query, searchParams.filter, searchParams.mode);
         await updatePanelSettings(searchPanel, searchParams); // Update panel to reflect global settings
         const results = await runSearch(DatabaseManager.getDatabase(), searchParams);
         lastSearchResults = results; // Cache the results
@@ -991,7 +993,7 @@ joplin.plugins.register({
       
       // Clear search params
       clearObjectReferences(searchParams);
-      searchParams = { query: [[]], filter: '', displayInNote: 'false' };
+      searchParams = { query: [[]], filter: '', displayInNote: 'false', mode: 'dnf' };
       
       // Clear table columns and default values
       currentTableColumns.length = 0;

--- a/src/noteView.ts
+++ b/src/noteView.ts
@@ -94,11 +94,10 @@ export async function displayResultsInNote(
   if (!viewList.includes(savedQuery.displayInNote)) { return null; }
 
   const displayColors = viewSettings.noteViewColorTitles;
-  const groupingMode = savedQuery.options?.resultGrouping || resultSettings.resultGrouping;
   const noteViewLocation = viewSettings.noteViewLocation;
 
   // Run search with sorting options
-  const results = await runSearch(db, savedQuery.query, groupingMode, savedQuery.options);
+  const results = await runSearch(db, savedQuery);
 
   // Apply filtering and limit
   let filteredResults = await filterResults(results, savedQuery.filter, viewSettings);

--- a/src/search.ts
+++ b/src/search.ts
@@ -163,8 +163,10 @@ async function getQueryResults(
         for (const tag of db.getTags()) {
           if (minValue) {
             if (minValue.startsWith('*')) {
+              // Simple suffix check
               if (!tag.endsWith(minValue.slice(1))) { continue; }
             } else if (minValue.endsWith('*')) {
+              // Combined prefix + range check
               if (!tag.startsWith(minValue.slice(0, -1))) { continue; }
             } else if (!isTagInRange(tag, minValue, maxValue, tagSettings.valueDelim)) {
               continue;
@@ -172,8 +174,10 @@ async function getQueryResults(
           }
           if (maxValue) {
             if (maxValue.startsWith('*')) {
+              // Simple suffix check
               if (!tag.endsWith(maxValue.slice(1))) { continue; }
             } else if (maxValue.endsWith('*')) {
+              // Combined prefix + range check
               if (!tag.startsWith(maxValue.slice(0, -1))) { continue; }
             } else if (!isTagInRange(tag, minValue, maxValue, tagSettings.valueDelim)) {
               continue;

--- a/src/search.ts
+++ b/src/search.ts
@@ -27,6 +27,8 @@ export interface QueryRecord {
   filter: string;
   /** How to display results in the note: 'false', 'list', 'table', or 'kanban' */
   displayInNote: string;
+  /** Query interpretation mode: 'dnf' (OR-of-ANDs) or 'cnf' (AND-of-ORs) */
+  mode?: 'dnf' | 'cnf';
   /** Optional display settings */
   options?: {
     includeCols?: string;

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -1304,7 +1304,7 @@ export async function saveQuery(
  */
 export function loadQuery(note: any): QueryRecord {
   const record = note.body.match(REGEX.findQuery);
-  let loadedQuery: QueryRecord = { query: [[]], filter: '', displayInNote: 'false' };
+  let loadedQuery: QueryRecord = { query: [[]], filter: '', displayInNote: 'false', mode: 'dnf' };
   if (record) {
     try {
       // Strip the code block delimiters, and remove decorations

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -1388,10 +1388,10 @@ function validateQuery(query: QueryRecord): QueryRecord {
   }
 
   // Validate and default mode
-  if (query.mode && !['dnf', 'cnf'].includes(query.mode)) {
-    console.warn('validateQuery: invalid mode:', query.mode);
-  }
   if (!query.mode || !['dnf', 'cnf'].includes(query.mode)) {
+    if (query.mode) {
+      console.warn('validateQuery: invalid mode:', query.mode);
+    }
     query.mode = 'dnf';
   }
 

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -1381,6 +1381,14 @@ function validateQuery(query: QueryRecord): QueryRecord {
     query.query = [[]];
   }
 
+  // Validate and default mode
+  if (query.mode && !['dnf', 'cnf'].includes(query.mode)) {
+    console.warn('validateQuery: invalid mode:', query.mode);
+  }
+  if (!query.mode || !['dnf', 'cnf'].includes(query.mode)) {
+    query.mode = 'dnf';
+  }
+
   // Normalise sort order if present
   if (query.options?.sortOrder) {
     query.options.sortOrder = ensureSortOrderString(query.options.sortOrder);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -509,5 +509,12 @@ export function validatePanelMessage(message: any): any {
     validated.message = validateString(message.message, 'message', VALIDATION_LIMITS.MAX_SETTING_VALUE_LENGTH);
   }
 
+  if ('mode' in message) {
+    const mode = validateString(message.mode, 'mode', 10);
+    if (['dnf', 'cnf'].includes(mode)) {
+      validated.mode = mode;
+    }
+  }
+
   return validated;
 } 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -517,4 +517,4 @@ export function validatePanelMessage(message: any): any {
   }
 
   return validated;
-} 
+}


### PR DESCRIPTION
## Summary
- Add CNF (Conjunctive Normal Form) query mode alongside the existing DNF default
- Right-click in the query area to toggle between **OR (any group)** and **AND (all groups)**
- Refactor `runSearch` signature to accept `QueryRecord` directly, simplifying all 19 call sites

## Details

The query system uses `Query[][]` where the meaning of the two dimensions depends on mode:
- **DNF** (default): inner = AND, outer = OR → `(A AND B) OR (C AND D)`
- **CNF**: inner = OR, outer = AND → `(A OR B) AND (C OR D)`

Mode is stored in `QueryRecord.mode`, persisted in saved queries, and defaults to `'dnf'` for backward compatibility. Legacy queries without a `mode` field work unchanged.

## Test plan
- [x] Build: `npm run dist`
- [x] Default behaviour (DNF) — existing queries work unchanged
- [x] Right-click in query area → toggle to AND (all groups) — labels swap, checkmark moves
- [x] Create a CNF query and verify correct results
- [x] Save query → verify JSON includes `"mode": "cnf"`
- [x] Reload note → verify CNF mode preserved
- [x] Load saved CNF query from dropdown → verify mode preserved
- [x] In-note display (list/table/kanban) respects mode
- [x] Toggle back to OR (any group) — results revert
- [x] Clear query → mode resets to DNF
- [x] Legacy queries (no mode field) default to DNF