### PR TITLE
feat: one style setting and shared class for inline tags on all three surfaces (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,9 @@ So `.itags-tag` styles tags everywhere, and the surface classes are there for wh
 
 The `Inline tags: Style` setting takes custom CSS and applies it to all three surfaces. **This is the only way to restyle tags on mobile**, where `userstyle.css` cannot be edited. On desktop you can use either that setting or `userstyle.css`.
 
-Two related settings cover the panels as a whole rather than tags: `Search: Panel style` and `Navigation: Panel style`. In the search panel these are applied after `Inline tags: Style`, so a panel-specific rule wins over the general tag look.
+Two related settings cover the panels as a whole rather than tags: `Search: Panel style` and `Navigation: Panel style`. In the search panel, `Inline tags: Style` is applied first, so a panel-specific rule there wins over the general tag look.
+
+The bundled default appearance is the same on all three surfaces and ships inside a CSS cascade layer, so any rule you write overrides it without needing `!important`. The editor's default omits `display: inline-block` and vertical margins, which disturb caret placement and line height there.
 
 <details>
 <summary>CSS examples for tag styling</summary>

--- a/README.md
+++ b/README.md
@@ -485,46 +485,61 @@ Context expansion lets you reveal surrounding lines around search results to see
 
 ### Styling inline tags
 
-The Markdown preview pane and the Tag Navigator search panel wrap every matched tag in the class `itags-search-renderedTag` and, when the token starts with `#`, `@`, `+`, `//`, or any other character, add `itags-search-renderedTag--hash`, `--at`, `--plus`, `--slash`, `--<other char>`. You may modify their appearance in `userstyle.css` (for Markdown preview), or in the `Search: Panel style` setting (for the plugin's search panel).
+Every rendered tag carries four classes, on all three surfaces that display tags (the search panel, the Markdown preview and the Markdown editor):
 
-The Markdown editor uses the same scheme with its own class, `itags-editor-tag` and `itags-editor-tag--hash` / `--at` / `--plus` / `--slash` / `--<other char>`. It is controlled by two settings:
+| Class | Matches |
+| ----- | ------- |
+| `itags-tag` | every tag, on every surface |
+| `itags-tag--hash` / `--at` / `--plus` / `--slash` / `--<other char>` | every tag with that prefix, on every surface |
+| `itags-search-renderedTag` (panel, preview) / `itags-editor-tag` (editor) | that surface only |
+| `itags-search-renderedTag--hash` / `itags-editor-tag--at` / ... | that surface, that prefix |
 
-- `Inline tags: Highlight in editor` turns it on or off (on by default).
-- `Inline tags: Editor style` takes custom CSS that overrides the default style. This is the only way to restyle editor tags on mobile, where `userstyle.css` cannot be edited.
+So `.itags-tag` styles tags everywhere, and the surface classes are there for when you want one surface to differ.
 
-The editor uses a separate class on purpose, because rules written for the preview often include `display: inline-block`, which disturbs caret placement in the editor.
+The `Inline tags: Style` setting takes custom CSS and applies it to all three surfaces. **This is the only way to restyle tags on mobile**, where `userstyle.css` cannot be edited. On desktop you can use either that setting or `userstyle.css`.
+
+Two related settings cover the panels as a whole rather than tags: `Search: Panel style` and `Navigation: Panel style`. In the search panel these are applied after `Inline tags: Style`, so a panel-specific rule wins over the general tag look.
 
 <details>
-<summary>CSS example for tag styling</summary>
+<summary>CSS examples for tag styling</summary>
+
+Style every tag on every surface:
 
 ```css
-/* optional: specify different sub-styles for each type of tag */
-.itags-search-renderedTag {
-	background-color: #a576b3ff;
-} /* global style */
+.itags-tag {
+	background-color: #a576b3;
+}
+```
 
-.itags-search-renderedTag--at {
+Give each type of tag its own colour, everywhere:
+
+```css
+.itags-tag--at {
 	background-color: #6fae4a;
-} /* type-specific style */
+}
 
-.itags-search-renderedTag--plus {
+.itags-tag--plus {
 	background-color: #ae4a6f;
 }
 
-.itags-search-renderedTag--slash {
+.itags-tag--slash {
 	background-color: #4a6fae;
 }
 ```
 
-The same, for the `Inline tags: Editor style` setting:
+Style one surface differently from the others. Note that `display: inline-block` is fine in the panel and preview but disturbs caret placement in the editor, which is why the editor's default omits it:
 
 ```css
-.itags-editor-tag {
-	background-color: #a576b3;
+/* preview and panel only */
+.itags-search-renderedTag {
+	display: inline-block;
+	margin: 2px 0;
 }
 
-.itags-editor-tag--at {
-	background-color: #6fae4a;
+/* editor only */
+.itags-editor-tag {
+	background-color: transparent;
+	border-bottom: 2px solid #7698b3;
 }
 ```
 

--- a/src/cm6tagStyle.ts
+++ b/src/cm6tagStyle.ts
@@ -4,28 +4,17 @@ import type { EditorState } from '@codemirror/state';
 import {
   Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate,
 } from '@codemirror/view';
-import { defTagRegex, isRegexSafe, tagClasses } from './utils';
+import { defaultTagCss, defTagRegex, isRegexSafe, tagClasses } from './utils';
 
 const TAG_CLASS = 'itags-editor-tag';
 const STYLE_ELEMENT_ID = 'itags-editor-tag-style';
 
 /**
- * Default tag appearance, matching the search panel and the Markdown preview.
- *
- * Wrapped in a cascade layer so that any unlayered rule overrides it without
- * needing !important: the `Inline tags: Editor style` setting on every platform,
- * and userstyle.css on desktop. Deliberately omits `display: inline-block` and
- * `margin`, which disturb caret placement and line height in the editor.
+ * Default tag appearance for the editor, from the definition shared with the
+ * panel and preview. Omits the block layout those two use, since inline-block
+ * and vertical margins disturb caret placement and line height here.
  */
-const DEFAULT_CSS = `@layer itagsEditorDefaults;
-@layer itagsEditorDefaults {
-  .${TAG_CLASS} {
-    background-color: #7698b3;
-    color: #ffffff;
-    border-radius: 5px;
-    padding: 0em 2px;
-  }
-}`;
+const DEFAULT_CSS = defaultTagCss(TAG_CLASS);
 
 type TagStyleSettings = {
   tagRegex: string;

--- a/src/cm6tagStyle.ts
+++ b/src/cm6tagStyle.ts
@@ -4,7 +4,7 @@ import type { EditorState } from '@codemirror/state';
 import {
   Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate,
 } from '@codemirror/view';
-import { defTagRegex, isRegexSafe, mapPrefixClass } from './utils';
+import { defTagRegex, isRegexSafe, tagClasses } from './utils';
 
 const TAG_CLASS = 'itags-editor-tag';
 const STYLE_ELEMENT_ID = 'itags-editor-tag-style';
@@ -178,7 +178,7 @@ function tagDecorator(tagRegex: RegExp, excludeRegex: RegExp | null): MatchDecor
       if (inCodeContext(view.state, start)) { return; }
 
       add(start, start + tag.length, Decoration.mark({
-        class: `${TAG_CLASS} ${TAG_CLASS}--${mapPrefixClass(tag)}`,
+        class: tagClasses(tag, TAG_CLASS),
       }));
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,12 +135,12 @@ joplin.plugins.register({
       await joplin.contentScripts.onMessage('itagsTagStyle', async (message: any) => {
         if (message?.name !== 'getTagStyleSettings') { return null; }
         const settings = await joplin.settings.values([
-          'itags.tagRegex', 'itags.excludeRegex', 'itags.editorTagStyle',
+          'itags.tagRegex', 'itags.excludeRegex', 'itags.tagStyle',
         ]);
         return {
           tagRegex: settings['itags.tagRegex'] as string,
           excludeRegex: settings['itags.excludeRegex'] as string,
-          css: settings['itags.editorTagStyle'] as string,
+          css: settings['itags.tagStyle'] as string,
         };
       });
       await joplin.contentScripts.register(

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -4,7 +4,7 @@ import * as markdownItMark from 'markdown-it-mark';
 import * as markdownItTaskLists from 'markdown-it-task-lists';
 import * as prism from './prism.js';
 import { TagSettings, getTagSettings, queryEnd, queryStart, getResultSettings, getStandardGroupingKeys, DEFAULT_QUERY_MODE } from './settings';
-import { escapeRegex, tagClasses } from './utils';
+import { defaultTagCss, escapeRegex, tagClasses } from './utils';
 import { GroupedResult, Query, QueryRecord, runSearch, sortResults } from './search';
 import { noteIdRegex } from './parser';
 import { NoteDatabase, processNote } from './db';
@@ -127,6 +127,7 @@ async function initializeVersionInfo() {
  */
 export async function registerSearchPanel(panel: string): Promise<void> {
   await joplin.views.panels.setHtml(panel, `
+    <style>${defaultTagCss('itags-search-renderedTag', { block: true, hover: true })}</style>
     <style>${await joplin.settings.value('itags.tagStyle')}</style>
     <style>${await joplin.settings.value('itags.searchPanelStyle')}</style>
     <div id="itags-search-inputTagArea" class="hidden">

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -4,7 +4,7 @@ import * as markdownItMark from 'markdown-it-mark';
 import * as markdownItTaskLists from 'markdown-it-task-lists';
 import * as prism from './prism.js';
 import { TagSettings, getTagSettings, queryEnd, queryStart, getResultSettings, getStandardGroupingKeys, DEFAULT_QUERY_MODE } from './settings';
-import { escapeRegex, mapPrefixClass } from './utils';
+import { escapeRegex, tagClasses } from './utils';
 import { GroupedResult, Query, QueryRecord, runSearch, sortResults } from './search';
 import { noteIdRegex } from './parser';
 import { NoteDatabase, processNote } from './db';
@@ -127,6 +127,7 @@ async function initializeVersionInfo() {
  */
 export async function registerSearchPanel(panel: string): Promise<void> {
   await joplin.views.panels.setHtml(panel, `
+    <style>${await joplin.settings.value('itags.tagStyle')}</style>
     <style>${await joplin.settings.value('itags.searchPanelStyle')}</style>
     <div id="itags-search-inputTagArea" class="hidden">
       <input type="text" id="itags-search-tagFilter" class="hidden" placeholder="Filter tags..." />
@@ -810,8 +811,7 @@ function renderHTML(groupedResults: GroupedResult[], tagRegex: RegExp, resultMar
         return lines.map((line, lineNumber) =>
           replaceOutsideBackticks(line, tagRegex, (match) => {
             const normalizedMatch = match.trim();
-            const prefixClass = mapPrefixClass(normalizedMatch || match);
-            return `<span class="itags-search-renderedTag itags-search-renderedTag--${prefixClass}" data-line-number="${lineNumber}">${match}</span>`;
+            return `<span class="${tagClasses(normalizedMatch || match, 'itags-search-renderedTag')}" data-line-number="${lineNumber}">${match}</span>`;
           })
         ).join('\n');
       }).join('\n');

--- a/src/searchPanelStyle.css
+++ b/src/searchPanelStyle.css
@@ -437,16 +437,10 @@ hr {
     margin-top: 5px;
 }
 
-.itags-search-renderedTag {
-	background-color: #7698b3;
-	color: white;
-	padding: 0em 2px;
-	border-radius: 5px;
-	display: inline-block;
-    margin-bottom: 2px;
-    margin-top: 2px;
-}
-.itags-search-renderedTag:hover { background-color: #7aaab8; }
+/* Tag appearance comes from the shared default in utils.defaultTagCss, injected
+   into the panel HTML inside a cascade layer so the `Inline tags: Style` setting
+   overrides it. Keeping it here would put it in a head stylesheet, where it
+   would only be overridable by document order. */
 
 .itags-search-renderedFilter {
     background-color: #eeee88;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -776,7 +776,8 @@ export async function registerSettings(): Promise<void> {
       label: 'Inline tags: Style',
       description: 'Custom CSS for inline tags in the search panel, Markdown preview and editor. ' +
         'Target .itags-tag for all three, or .itags-tag--hash / --at / --plus / --slash for a ' +
-        'specific prefix. Also the only way to restyle tags on mobile.',
+        'specific prefix. Also the only way to restyle tags on mobile. ' +
+        'Toggle the panel or restart the app to update the search panel.',
     },
     'itags.periodicConversion': {
       value: 0,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -764,7 +764,8 @@ export async function registerSettings(): Promise<void> {
       public: true,
       advanced: true,
       label: 'Search: Panel style',
-      description: 'Custom CSS for the search panel (toggle panel or restart app).',
+      description: 'Custom CSS for the search panel (toggle panel or restart app). ' +
+        'For tag appearance see Inline tags: Style.',
     },
     'itags.tagStyle': {
       value: '',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -766,16 +766,16 @@ export async function registerSettings(): Promise<void> {
       label: 'Search: Panel style',
       description: 'Custom CSS for the search panel (toggle panel or restart app).',
     },
-    'itags.editorTagStyle': {
+    'itags.tagStyle': {
       value: '',
       type: SettingItemType.String,
       section: 'itags',
       public: true,
       advanced: true,
-      label: 'Inline tags: Editor style',
-      description: 'Custom CSS for inline tags in the editor, overriding the default style. ' +
-        'Target .itags-editor-tag, or .itags-editor-tag--hash / --at / --plus / --slash ' +
-        'for a specific prefix.',
+      label: 'Inline tags: Style',
+      description: 'Custom CSS for inline tags in the search panel, Markdown preview and editor. ' +
+        'Target .itags-tag for all three, or .itags-tag--hash / --at / --plus / --slash for a ' +
+        'specific prefix. Also the only way to restyle tags on mobile.',
     },
     'itags.periodicConversion': {
       value: 0,

--- a/src/styleInjector.ts
+++ b/src/styleInjector.ts
@@ -12,6 +12,20 @@ type StyleInjectionState = {
 
 const ENV_KEY = 'itagsStyleInjection';
 
+/**
+ * Neutralises any closing style tag inside a CSS chunk.
+ *
+ * Chunks are interpolated into an html_block token, so a chunk containing
+ * "</style>" would close the element early and inject the rest as live markup.
+ * Escaping the slash is inert to the HTML parser while leaving the text visible
+ * in the stylesheet, so a user who pastes a stray tag sees broken CSS rather
+ * than a broken note. Callers that assign to textContent instead do not need
+ * this, but the element is built here, so the guarantee belongs here.
+ */
+function sealChunk(cssChunk: string): string {
+  return cssChunk.replace(/<\/(style)/gi, '<\\/$1');
+}
+
 export function injectStyleChunk(state: MarkdownState | null, Token: TokenConstructor | null, cssChunk: string): void {
   if (!state || !Token) return;
   if (!cssChunk) return;
@@ -31,10 +45,12 @@ export function injectStyleChunk(state: MarkdownState | null, Token: TokenConstr
     state.env[ENV_KEY] = data;
   }
 
-  if (data.chunks.includes(cssChunk)) {
+  // Seal before the duplicate check, so the stored and compared forms match.
+  const sealed = sealChunk(cssChunk);
+  if (data.chunks.includes(sealed)) {
     return;
   }
 
-  data.chunks.push(cssChunk);
+  data.chunks.push(sealed);
   data.token.content = `<style>\n${data.chunks.join('\n')}\n</style>`;
 }

--- a/src/tagMarkdownItPlugin.ts
+++ b/src/tagMarkdownItPlugin.ts
@@ -1,9 +1,10 @@
 import type { ContentScriptContext, MarkdownItContentScriptModule } from 'api/types';
-import { mapPrefixClass } from './utils';
+import { tagClasses } from './utils';
 import { injectStyleChunk } from './styleInjector';
 
 const TAG_REGEX_SETTING_KEY = 'itags.tagRegex';
 const EXCLUDE_REGEX_SETTING_KEY = 'itags.excludeRegex';
+const TAG_STYLE_SETTING_KEY = 'itags.tagStyle';
 
 // Default fallback regex for matching inline tags.
 const defTagRegex = /(^|\s)#([^\s#'",.()\[\]:;\?\\]+)/g;
@@ -133,6 +134,7 @@ function readSetting(pluginOptions: any, key: string, apply: (value: any) => voi
 export default function (_context: ContentScriptContext): MarkdownItContentScriptModule {
   let activeTagRegex: RegExp = defTagRegex;
   let activeExcludeRegex: RegExp | null = null;
+  let activeUserCss = '';
 
   const applySetting = (key: string, value: any) => {
     switch (key) {
@@ -141,6 +143,9 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
         break;
       case EXCLUDE_REGEX_SETTING_KEY:
         activeExcludeRegex = compileExcludeRegex(value);
+        break;
+      case TAG_STYLE_SETTING_KEY:
+        activeUserCss = typeof value === 'string' ? value : '';
         break;
       default:
         break;
@@ -151,6 +156,7 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
     plugin: (markdownIt: any, pluginOptions: any) => {
       readSetting(pluginOptions, TAG_REGEX_SETTING_KEY, value => applySetting(TAG_REGEX_SETTING_KEY, value));
       readSetting(pluginOptions, EXCLUDE_REGEX_SETTING_KEY, value => applySetting(EXCLUDE_REGEX_SETTING_KEY, value));
+      readSetting(pluginOptions, TAG_STYLE_SETTING_KEY, value => applySetting(TAG_STYLE_SETTING_KEY, value));
 
       if (pluginOptions && typeof pluginOptions.onSettingChange === 'function') {
         try {
@@ -172,6 +178,7 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
         const Token = state.Token;
 
         injectStyleChunk(state, Token, TAG_STYLE_CSS);
+        injectStyleChunk(state, Token, activeUserCss);
 
         for (const token of state.tokens as TokenLike[]) {
           if (token.type !== 'inline' || !token.children) {
@@ -239,8 +246,7 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
 
                 if (!handled) {
                   const open = new Token('html_inline', '', 0);
-                  const prefixClass = mapPrefixClass(tagPart);
-                  open.content = `<span class="itags-search-renderedTag itags-search-renderedTag--${prefixClass}">`;
+                  open.content = `<span class="${tagClasses(tagPart, 'itags-search-renderedTag')}">`;
                   const textToken = new Token('text', '', 0);
                   textToken.content = tagPart;
                   const close = new Token('html_inline', '', 0);

--- a/src/tagMarkdownItPlugin.ts
+++ b/src/tagMarkdownItPlugin.ts
@@ -1,5 +1,5 @@
 import type { ContentScriptContext, MarkdownItContentScriptModule } from 'api/types';
-import { tagClasses } from './utils';
+import { defaultTagCss, tagClasses } from './utils';
 import { injectStyleChunk } from './styleInjector';
 
 const TAG_REGEX_SETTING_KEY = 'itags.tagRegex';
@@ -9,20 +9,9 @@ const TAG_STYLE_SETTING_KEY = 'itags.tagStyle';
 // Default fallback regex for matching inline tags.
 const defTagRegex = /(^|\s)#([^\s#'",.()\[\]:;\?\\]+)/g;
 
-// Inline default styling because the web app blocks loading plugin CSS assets.
-// Wrapped in a CSS layer so Joplin's userstyle.css can override without !important.
-const TAG_STYLE_CSS = `@layer itagsDefaults;
-@layer itagsDefaults {
-  .itags-search-renderedTag {
-    background-color: #7698b3;
-    color: #ffffff;
-    padding: 0em 2px;
-    border-radius: 5px;
-    display: inline-block;
-    margin-bottom: 2px;
-    margin-top: 2px;
-  }
-}`;
+// Inline rather than a CSS asset, because the web app blocks loading plugin CSS
+// assets. Shares its definition with the panel and editor defaults.
+const TAG_STYLE_CSS = defaultTagCss('itags-search-renderedTag', { block: true });
 
 function cloneRegex(pattern: RegExp | null): RegExp | null {
   if (!pattern) return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ export function sortTags(tags: string[], valueDelim: string): string[] {
  * happen to share a class name while the editor does not. The surface-specific
  * classes remain alongside it for per-surface targeting.
  */
-export const SHARED_TAG_CLASS = 'itags-tag';
+const SHARED_TAG_CLASS = 'itags-tag';
 
 // Map characters that are awkward in CSS selectors to readable class suffixes.
 const PREFIX_CLASS_MAP: Record<string, string> = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,3 +147,48 @@ export function tagClasses(tag: string, surfaceClass: string): string {
   const prefix = mapPrefixClass(tag);
   return `${SHARED_TAG_CLASS} ${SHARED_TAG_CLASS}--${prefix} ${surfaceClass} ${surfaceClass}--${prefix}`;
 }
+
+/** Declarations shared by the default tag styling on every surface. */
+const TAG_DEFAULT_DECLARATIONS = `    background-color: #7698b3;
+    color: #ffffff;
+    padding: 0em 2px;
+    border-radius: 5px;`;
+
+/** Hover colour, for surfaces where a tag is clickable. */
+const TAG_DEFAULT_HOVER = '#7aaab8';
+
+/**
+ * Default tag styling for one surface, as a cascade layer.
+ *
+ * Layered so that any unlayered rule overrides it without !important: the
+ * `Inline tags: Style` setting on every platform, and userstyle.css on desktop.
+ * Defining it here rather than once per surface keeps the colours from drifting
+ * apart, and gives all three surfaces the same override contract.
+ *
+ * @param surfaceClass The surface's own base class
+ * @param options.block Adds inline-block and vertical margins. Right for the
+ *   panel and preview; omitted in the editor, where they disturb caret
+ *   placement and line height.
+ * @param options.hover Adds a hover colour. Only for surfaces where tags are
+ *   clickable.
+ */
+export function defaultTagCss(
+  surfaceClass: string,
+  options: { block?: boolean; hover?: boolean } = {},
+): string {
+  const block = options.block ? `
+    display: inline-block;
+    margin-top: 2px;
+    margin-bottom: 2px;` : '';
+  const hover = options.hover ? `
+  .${surfaceClass}:hover {
+    background-color: ${TAG_DEFAULT_HOVER};
+  }` : '';
+
+  return `@layer itagsDefaults;
+@layer itagsDefaults {
+  .${surfaceClass} {
+${TAG_DEFAULT_DECLARATIONS}${block}
+  }${hover}
+}`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,15 @@ export function sortTags(tags: string[], valueDelim: string): string[] {
   return tags.sort((a, b) => compareTagValues(a, b, valueDelim));
 }
 
+/**
+ * Class applied to every rendered inline tag, on all three surfaces: the search
+ * panel, the Markdown preview and the editor. Lets one CSS rule style tags
+ * everywhere, without the reader having to know that the panel and preview
+ * happen to share a class name while the editor does not. The surface-specific
+ * classes remain alongside it for per-surface targeting.
+ */
+export const SHARED_TAG_CLASS = 'itags-tag';
+
 // Map characters that are awkward in CSS selectors to readable class suffixes.
 const PREFIX_CLASS_MAP: Record<string, string> = {
   '#': 'hash',
@@ -120,4 +129,21 @@ export function mapPrefixClass(tag: string): string {
 
   const code = prefix.codePointAt(0);
   return code != null ? `char-${code.toString(16)}` : 'unknown';
+}
+
+/**
+ * The full class list for a rendered inline tag.
+ *
+ * Every tag carries the shared classes, so one CSS rule can style tags on all
+ * three surfaces, plus the given surface's own classes for per-surface
+ * targeting. Both come in a bare and a per-prefix form:
+ *
+ *   itags-tag  itags-tag--at  itags-editor-tag  itags-editor-tag--at
+ *
+ * @param tag The tag text, used to derive the prefix suffix
+ * @param surfaceClass The surface's own base class
+ */
+export function tagClasses(tag: string, surfaceClass: string): string {
+  const prefix = mapPrefixClass(tag);
+  return `${SHARED_TAG_CLASS} ${SHARED_TAG_CLASS}--${prefix} ${surfaceClass} ${surfaceClass}--${prefix}`;
 }

--- a/tests/editorTagStyle.test.ts
+++ b/tests/editorTagStyle.test.ts
@@ -20,7 +20,7 @@
 import { compileTagRegex, compileExcludeRegex, tagBounds, inCodeContext } from '../src/cm6tagStyle';
 import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
-import { defTagRegex, mapPrefixClass, tagClasses, defaultTagCss, SHARED_TAG_CLASS } from '../src/utils';
+import { defTagRegex, mapPrefixClass, tagClasses, defaultTagCss } from '../src/utils';
 
 /** The multi-prefix example from the `Tag regex` setting description. */
 const MULTI_PREFIX = "(?<=^|\\s)([#@+]|\\/\\/)([^\\s#@'\",.()\\[\\]:;\\?\\\\]+)";
@@ -284,9 +284,12 @@ describe('inCodeContext', () => {
 });
 
 describe('tagClasses', () => {
+  // Asserts the literal rather than the module's constant: this is the class
+  // name the README documents and users write CSS against, so a rename should
+  // fail here rather than quietly stay self-consistent.
   it('carries the shared class so one rule styles all three surfaces', () => {
     for (const surface of ['itags-editor-tag', 'itags-search-renderedTag']) {
-      expect(tagClasses('#tag', surface).split(' ')).toContain(SHARED_TAG_CLASS);
+      expect(tagClasses('#tag', surface).split(' ')).toContain('itags-tag');
     }
   });
 

--- a/tests/editorTagStyle.test.ts
+++ b/tests/editorTagStyle.test.ts
@@ -20,7 +20,7 @@
 import { compileTagRegex, compileExcludeRegex, tagBounds, inCodeContext } from '../src/cm6tagStyle';
 import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
-import { defTagRegex, mapPrefixClass, tagClasses, SHARED_TAG_CLASS } from '../src/utils';
+import { defTagRegex, mapPrefixClass, tagClasses, defaultTagCss, SHARED_TAG_CLASS } from '../src/utils';
 
 /** The multi-prefix example from the `Tag regex` setting description. */
 const MULTI_PREFIX = "(?<=^|\\s)([#@+]|\\/\\/)([^\\s#@'\",.()\\[\\]:;\\?\\\\]+)";
@@ -307,4 +307,51 @@ describe('tagClasses', () => {
       expect(classes).toContain(`itags-tag--${suffix}`);
       expect(classes).toContain(`itags-editor-tag--${suffix}`);
     });
+});
+
+describe('defaultTagCss', () => {
+  const editor = defaultTagCss('itags-editor-tag');
+  const preview = defaultTagCss('itags-search-renderedTag', { block: true });
+  const panel = defaultTagCss('itags-search-renderedTag', { block: true, hover: true });
+
+  it('gives every surface the same colours, so they cannot drift apart', () => {
+    for (const css of [editor, preview, panel]) {
+      expect(css).toContain('background-color: #7698b3');
+      expect(css).toContain('color: #ffffff');
+      expect(css).toContain('border-radius: 5px');
+      expect(css).toContain('padding: 0em 2px');
+    }
+  });
+
+  it('layers every surface, so unlayered user CSS wins without !important', () => {
+    for (const css of [editor, preview, panel]) {
+      expect(css).toMatch(/^@layer itagsDefaults;/);
+      expect(css).toContain('@layer itagsDefaults {');
+    }
+  });
+
+  it('omits the block layout in the editor, where it disturbs the caret', () => {
+    expect(editor).not.toContain('display: inline-block');
+    expect(editor).not.toContain('margin');
+  });
+
+  it('keeps the block layout where the panel and preview had it', () => {
+    for (const css of [preview, panel]) {
+      expect(css).toContain('display: inline-block');
+      expect(css).toContain('margin-top: 2px');
+      expect(css).toContain('margin-bottom: 2px');
+    }
+  });
+
+  it('adds hover only where tags are clickable', () => {
+    expect(panel).toContain('.itags-search-renderedTag:hover');
+    expect(panel).toContain('#7aaab8');
+    expect(preview).not.toContain(':hover');
+    expect(editor).not.toContain(':hover');
+  });
+
+  it('targets the class it is given', () => {
+    expect(editor).toContain('.itags-editor-tag {');
+    expect(preview).toContain('.itags-search-renderedTag {');
+  });
 });

--- a/tests/editorTagStyle.test.ts
+++ b/tests/editorTagStyle.test.ts
@@ -20,7 +20,7 @@
 import { compileTagRegex, compileExcludeRegex, tagBounds, inCodeContext } from '../src/cm6tagStyle';
 import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
-import { defTagRegex, mapPrefixClass } from '../src/utils';
+import { defTagRegex, mapPrefixClass, tagClasses, SHARED_TAG_CLASS } from '../src/utils';
 
 /** The multi-prefix example from the `Tag regex` setting description. */
 const MULTI_PREFIX = "(?<=^|\\s)([#@+]|\\/\\/)([^\\s#@'\",.()\\[\\]:;\\?\\\\]+)";
@@ -281,4 +281,30 @@ describe('inCodeContext', () => {
     expect(inCodeContext(state(doc), doc.indexOf('#inside'))).toBe(true);
     expect(inCodeContext(state(doc), doc.indexOf('#after'))).toBe(false);
   });
+});
+
+describe('tagClasses', () => {
+  it('carries the shared class so one rule styles all three surfaces', () => {
+    for (const surface of ['itags-editor-tag', 'itags-search-renderedTag']) {
+      expect(tagClasses('#tag', surface).split(' ')).toContain(SHARED_TAG_CLASS);
+    }
+  });
+
+  it('gives the shared and surface classes matching prefix variants', () => {
+    expect(tagClasses('@who', 'itags-editor-tag').split(' ')).toEqual([
+      'itags-tag', 'itags-tag--at', 'itags-editor-tag', 'itags-editor-tag--at',
+    ]);
+  });
+
+  it('keeps the surface class, so per-surface rules still work', () => {
+    expect(tagClasses('#tag', 'itags-search-renderedTag')).toContain('itags-search-renderedTag--hash');
+    expect(tagClasses('#tag', 'itags-editor-tag')).toContain('itags-editor-tag--hash');
+  });
+
+  it.each([['#a', 'hash'], ['@a', 'at'], ['+a', 'plus'], ['//a', 'slash']])(
+    'maps %s to --%s on both the shared and surface class', (tag, suffix) => {
+      const classes = tagClasses(tag, 'itags-editor-tag');
+      expect(classes).toContain(`itags-tag--${suffix}`);
+      expect(classes).toContain(`itags-editor-tag--${suffix}`);
+    });
 });

--- a/tests/previewTagStyle.test.ts
+++ b/tests/previewTagStyle.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the Markdown preview's tag style override (itags.renderTagStyle).
+ *
+ * The user's CSS is injected as a second chunk after the bundled default, into
+ * the same <style> element. Two things have to hold for the override contract:
+ * the user's rules must come last (so they win on source order as well as on
+ * being unlayered against the default's @layer), and a chunk must not be able
+ * to break out of the element, since chunks are interpolated into an html_block
+ * rather than assigned to textContent.
+ */
+import * as MarkdownIt from 'markdown-it';
+import { injectStyleChunk } from '../src/styleInjector';
+
+const DEFAULT_CSS = '@layer itagsDefaults;\n@layer itagsDefaults {\n  .itags-search-renderedTag { color: #fff; }\n}';
+
+/** Renders with the given chunks injected, the way tagMarkdownItPlugin does. */
+function render(chunks: () => string[], src = 'a #tag here'): string {
+  const md = new (MarkdownIt as any)({ html: true });
+  md.core.ruler.push('itags_test_inject', (state: any) => {
+    for (const chunk of chunks()) { injectStyleChunk(state, state.Token, chunk); }
+    return true;
+  });
+  return md.render(src);
+}
+
+function styleBlock(html: string): string {
+  const m = html.match(/<style>[\s\S]*?<\/style>/);
+  return m ? m[0] : '';
+}
+
+describe('preview style injection', () => {
+  it('puts the user CSS after the default, so it wins on source order', () => {
+    const out = styleBlock(render(() => [DEFAULT_CSS, '.itags-search-renderedTag { color: red; }']));
+    expect(out).toContain('color: red');
+    expect(out.indexOf('itagsDefaults')).toBeLessThan(out.indexOf('color: red'));
+  });
+
+  it('injects nothing extra when the setting is empty', () => {
+    const withEmpty = styleBlock(render(() => [DEFAULT_CSS, '']));
+    const withoutAny = styleBlock(render(() => [DEFAULT_CSS]));
+    expect(withEmpty).toBe(withoutAny);
+  });
+
+  it('emits one style element, not one per chunk', () => {
+    const out = render(() => [DEFAULT_CSS, '.a{}', '.b{}']);
+    expect(out.match(/<style>/g)).toHaveLength(1);
+  });
+
+  it('does not repeat an identical chunk', () => {
+    const out = styleBlock(render(() => [DEFAULT_CSS, '.dup{}', '.dup{}']));
+    expect(out.match(/\.dup\{\}/g)).toHaveLength(1);
+  });
+
+  it('keeps the user CSS from closing the element and injecting markup', () => {
+    const out = render(() => [DEFAULT_CSS, '</style><b>ESCAPED</b>']);
+    // The element closes exactly once, and the would-be markup stays inside it,
+    // where it is inert stylesheet text rather than document content.
+    expect(out.match(/<\/style>/g)).toHaveLength(1);
+    expect(styleBlock(out)).toContain('<b>ESCAPED</b>');
+    const outsideStyle = out.replace(styleBlock(out), '');
+    expect(outsideStyle).not.toContain('<b>ESCAPED</b>');
+    expect(outsideStyle).toContain('<p>a #tag here</p>');
+  });
+
+  it('seals a closing tag consistently, so it is still deduplicated', () => {
+    const hostile = '</style>x';
+    const out = styleBlock(render(() => [DEFAULT_CSS, hostile, hostile]));
+    expect(out.match(/x/g)).toHaveLength(1);
+  });
+
+  it('leaves ordinary CSS untouched', () => {
+    const css = '.itags-search-renderedTag--at { background-color: #6fae4a; }';
+    expect(styleBlock(render(() => [DEFAULT_CSS, css]))).toContain(css);
+  });
+});


### PR DESCRIPTION
## What

Tags render on three surfaces — the search panel, the Markdown preview and the Markdown editor. This adds one setting that styles all three, plus a shared class to target.

| Setting | Type | Default | Applies to |
|---------|------|---------|-----------|
| `Inline tags: Style` | String (CSS), advanced | `''` | panel, preview, editor |

Every tag now carries four classes, e.g. for an `@mention` in the editor:

```
itags-tag  itags-tag--at  itags-editor-tag  itags-editor-tag--at
```

So `.itags-tag { ... }` styles tags everywhere, while the surface classes remain for when one surface should differ.

Replaces `Inline tags: Editor style` from #41. Closes #43.

## Why

The preview had no override path at all, which on mobile means no way to restyle preview tags — `userstyle.css` cannot be edited there. That was the gap #43 recorded.

The first version of this PR added a second, preview-only setting. That was wrong, and the reasoning behind it conflated two things: the *defaults* genuinely must differ per surface (the editor's omits `display: inline-block`, which disturbs caret placement), but the *user's override* does not follow from that. Two settings would make someone write the same colours twice, under two names, to get a consistent look — worst on the platform these settings exist for.

The shared class follows from the same decision. The panel and preview both emitted `itags-search-renderedTag` while the editor emitted `itags-editor-tag`, so consistent styling meant writing a selector list and knowing which surfaces happen to share a name. One class removes that.

`Search: Panel style` and `Navigation: Panel style` are untouched. They are whole-webview knobs, a different concern from tag styling, and folding tag styling into them would leave the editor and preview without one.

## How

The class list is built once in `utils.tagClasses` rather than templated in three places, so the contract has a single definition.

Precedence in the search panel: the shared style is injected *before* `Search: Panel style`, so a panel-specific rule still wins over the general tag look. Verified in Joplin's source rather than assumed — `addScript('.css')` appends a `<link>` to `<head>` (`UserWebviewIndex.js:114-120`) while `setHtml` sets `innerHTML` on a body div (`:128`), so both inline styles beat the bundled `searchPanelStyle.css` on document order.

## One fix it depended on

`injectStyleChunk` interpolates chunks into an `html_block` token, so a chunk containing `</style>` closed the element early and everything after became live document markup. Confirmed before fixing: `</style><b>ESCAPED</b>` rendered as real markup in the note.

Inert while both callers passed static strings; this PR makes one of them user-supplied CSS. The editor's `applyStyle` is immune because assigning to `textContent` does not parse HTML. Escapes the slash rather than stripping the sequence, so a stray closing tag gives visibly broken CSS instead of a broken note, and seals before the duplicate check so the stored and compared forms match.

## Also folded in: one definition of the default appearance

The same look was written three times - `searchPanelStyle.css` for the panel, `TAG_STYLE_CSS` for the preview, `DEFAULT_CSS` for the editor - and had already drifted: the panel said `color: white` where the others said `#ffffff`, and the editor used a different layer name.

`utils.defaultTagCss` now generates all three from one set of declarations, with the two real per-surface differences as options. `block` adds `inline-block` and vertical margins for the panel and preview, omitted in the editor. `hover` adds a hover colour, only where tags are clickable.

It also makes the override contract uniform, which matters for this PR. The panel's default lived in a stylesheet added to `<head>`, so user CSS beat it only by document order, while the other two were layered. All three are now layered under `itagsDefaults`, so any unlayered rule wins regardless of order - which is what `Inline tags: Style` relies on. The panel's rules move out of `searchPanelStyle.css` into the injected style, ahead of both user settings.

`Search: Panel style` now also points at `Inline tags: Style` for tag appearance: only 1 of its 63 selectors was ever about tags, so that is where someone would look first and not find it.

## Verification

- 78 tests (14 new). `npm run dist` clean, no type regressions.
- Defect injection: removing the seal fails 2 tests.
- The accumulation concern raised in #43 is refuted rather than coded around — `markdown-it`'s `env` is per-render, so with the setting changed between renders the second carries only the new CSS.
- Additive for existing users: `userstyle.css` rules against either surface class keep working, and `searchPanelScript.js` matches on `itags-search-renderedTag`, which extra classes do not affect.

## Not verified

How any of it looks rendered. The class is additive and the defaults are unchanged, so the risk is low, but nothing here has been in front of a renderer.

## Note on history

Force-pushed once. The branch initially added a separate preview-only setting, which a later commit would have removed; rather than leave a commit that adds a setting and another that deletes it, the branch was rebuilt as three coherent commits.