### PR TITLE
fix: locate the tag by trimming, not by searching for '#' (#42)

### DIFF
--- a/src/cm6tagStyle.ts
+++ b/src/cm6tagStyle.ts
@@ -4,7 +4,7 @@ import type { EditorState } from '@codemirror/state';
 import {
   Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate,
 } from '@codemirror/view';
-import { defaultTagCss, defTagRegex, isRegexSafe, tagClasses } from './utils';
+import { defaultTagCss, defTagRegex, isRegexSafe, tagBounds, tagClasses } from './utils';
 
 const TAG_CLASS = 'itags-editor-tag';
 const STYLE_ELEMENT_ID = 'itags-editor-tag-style';
@@ -126,19 +126,6 @@ export function inCodeContext(state: EditorState, pos: number): boolean {
     node = node.parent;
   }
   return false;
-}
-
-/**
- * Locates the tag within a raw match, as an offset and the tag text.
- *
- * A tag regex may capture the whitespace around the tag rather than use a
- * lookbehind - (^|\s)#... leads with a space, (^|\s)#(\S+)(\s|$) trails one -
- * so the decoration is anchored on the tag itself, or the whitespace gets
- * painted. This is also what the panel maps its prefix class from.
- */
-export function tagBounds(matchText: string): { tag: string; lead: number } {
-  const tag = matchText.trim();
-  return { tag, lead: tag ? matchText.indexOf(tag) : 0 };
 }
 
 /**

--- a/src/tagMarkdownItPlugin.ts
+++ b/src/tagMarkdownItPlugin.ts
@@ -1,13 +1,10 @@
 import type { ContentScriptContext, MarkdownItContentScriptModule } from 'api/types';
-import { defaultTagCss, tagClasses } from './utils';
+import { defaultTagCss, defTagRegex, tagBounds, tagClasses } from './utils';
 import { injectStyleChunk } from './styleInjector';
 
 const TAG_REGEX_SETTING_KEY = 'itags.tagRegex';
 const EXCLUDE_REGEX_SETTING_KEY = 'itags.excludeRegex';
 const TAG_STYLE_SETTING_KEY = 'itags.tagStyle';
-
-// Default fallback regex for matching inline tags.
-const defTagRegex = /(^|\s)#([^\s#'",.()\[\]:;\?\\]+)/g;
 
 // Inline rather than a CSS asset, because the web app blocks loading plugin CSS
 // assets. Shares its definition with the panel and editor defaults.
@@ -199,9 +196,17 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
               }
 
               const fullMatch = match[0];
-              const hashIndexInMatch = fullMatch.indexOf('#');
-              const prefixPart = hashIndexInMatch > 0 ? fullMatch.slice(0, hashIndexInMatch) : '';
-              const tagPart = hashIndexInMatch >= 0 ? fullMatch.slice(hashIndexInMatch) : fullMatch;
+              // Anchor on the tag itself rather than on a hard-coded '#'. A regex
+              // may capture the whitespace around the tag, and splitting on '#'
+              // only stripped it for '#' tags: an @mention or +project from a
+              // capture-group regex kept its leading space inside the span, and
+              // the prefix class came out as --char-20 rather than --at.
+              const { tag: tagPart, lead } = tagBounds(fullMatch);
+              const prefixPart = fullMatch.slice(0, lead);
+              // Whatever the trim removed from the end still has to be emitted:
+              // cursor advances past the whole match, so anything not pushed here
+              // is dropped from the rendered output.
+              const suffixPart = fullMatch.slice(lead + tagPart.length);
 
               const matchStart = match.index;
               const matchEnd = matchStart + fullMatch.length;
@@ -243,6 +248,12 @@ export default function (_context: ContentScriptContext): MarkdownItContentScrip
                   newChildren.push(open, textToken, close);
                   handled = true;
                 }
+              }
+
+              if (suffixPart) {
+                const suffixToken = new Token('text', '', 0);
+                suffixToken.content = suffixPart;
+                newChildren.push(suffixToken);
               }
 
               const consumed = matchEnd;

--- a/src/tagMarkdownItPlugin.ts
+++ b/src/tagMarkdownItPlugin.ts
@@ -1,5 +1,5 @@
 import type { ContentScriptContext, MarkdownItContentScriptModule } from 'api/types';
-import { defaultTagCss, defTagRegex, tagBounds, tagClasses } from './utils';
+import { defaultTagCss, defTagRegex, isRegexSafe, tagBounds, tagClasses } from './utils';
 import { injectStyleChunk } from './styleInjector';
 
 const TAG_REGEX_SETTING_KEY = 'itags.tagRegex';
@@ -20,6 +20,14 @@ function compileTagRegex(value: unknown): RegExp {
     return defTagRegex;
   }
 
+  // Shared with the indexer and the editor. The loop below advances lastIndex
+  // itself, so a zero-length match cannot hang this surface, but a
+  // catastrophically backtracking pattern would still run on every render.
+  if (!isRegexSafe(value)) {
+    console.warn('Tag Navigator: tag regex can backtrack catastrophically, falling back to default.', value);
+    return defTagRegex;
+  }
+
   try {
     return new RegExp(value, 'g');
   } catch (error) {
@@ -30,6 +38,11 @@ function compileTagRegex(value: unknown): RegExp {
 
 function compileExcludeRegex(value: unknown): RegExp | null {
   if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  if (!isRegexSafe(value)) {
+    console.warn('Tag Navigator: exclude regex can backtrack catastrophically, ignoring.', value);
     return null;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -192,3 +192,16 @@ ${TAG_DEFAULT_DECLARATIONS}${block}
   }${hover}
 }`;
 }
+
+/**
+ * Locates the tag within a raw match, as an offset and the tag text.
+ *
+ * A tag regex may capture the whitespace around the tag rather than use a
+ * lookbehind - (^|\s)#... leads with a space, (^|\s)#(\S+)(\s|$) trails one -
+ * so the decoration is anchored on the tag itself, or the whitespace gets
+ * painted. This is also what the panel maps its prefix class from.
+ */
+export function tagBounds(matchText: string): { tag: string; lead: number } {
+  const tag = matchText.trim();
+  return { tag, lead: tag ? matchText.indexOf(tag) : 0 };
+}

--- a/tests/editorTagStyle.test.ts
+++ b/tests/editorTagStyle.test.ts
@@ -17,10 +17,10 @@
  *
  * tagBounds is the arithmetic that decides which characters get painted.
  */
-import { compileTagRegex, compileExcludeRegex, tagBounds, inCodeContext } from '../src/cm6tagStyle';
+import { compileTagRegex, compileExcludeRegex, inCodeContext } from '../src/cm6tagStyle';
 import { EditorState } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
-import { defTagRegex, mapPrefixClass, tagClasses, defaultTagCss } from '../src/utils';
+import { defTagRegex, mapPrefixClass, tagClasses, defaultTagCss, tagBounds } from '../src/utils';
 
 /** The multi-prefix example from the `Tag regex` setting description. */
 const MULTI_PREFIX = "(?<=^|\\s)([#@+]|\\/\\/)([^\\s#@'\",.()\\[\\]:;\\?\\\\]+)";

--- a/tests/previewPrefix.test.ts
+++ b/tests/previewPrefix.test.ts
@@ -96,3 +96,41 @@ describe('prefix splitting', () => {
     expect(defTagRegex.source).toContain('(?<=^|\\s)');
   });
 });
+
+describe('regex safety', () => {
+  /** A pattern isRegexSafe rejects: the (a|a)* shape. */
+  const REDOS = '(?<=^|\\s)#(\\w+|\\w+)*$';
+  /** Matches the empty string, which the render loop must survive. */
+  const EMPTY_MATCHER = '#?\\w*';
+
+  let warn: jest.SpyInstance;
+  beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warn.mockRestore(); });
+
+  it('falls back to the default rather than running a backtracking tag regex', () => {
+    // The default still applies, so #tag is styled and foo#bar is not.
+    expect(tags(render('a #tag and foo#bar', REDOS))).toEqual([['hash', '#tag']]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('ignores a backtracking exclude regex rather than running it', () => {
+    // With the exclude ignored, both tags survive.
+    expect(tags(render('a #one and #two', '', '(#\\w+)+'))).toEqual([
+      ['hash', '#one'], ['hash', '#two'],
+    ]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('still renders an invalid regex as plain text via the default', () => {
+    expect(tags(render('a #tag here', '#['))).toEqual([['hash', '#tag']]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('terminates on a regex that can match the empty string', () => {
+    // isRegexSafe accepts this one, so it really runs. The render loop advances
+    // lastIndex itself, so it must finish and lose no text.
+    const html = render('a #tag b', EMPTY_MATCHER);
+    expect(textOf(html)).toContain('#tag');
+    expect(textOf(html).replace(/\s+/g, ' ').trim()).toBe('a #tag b');
+  });
+});

--- a/tests/previewPrefix.test.ts
+++ b/tests/previewPrefix.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for how the Markdown preview splits a match into prefix, tag and
+ * remainder (issue #42).
+ *
+ * A tag regex may or may not capture the whitespace around the tag. The
+ * preview used to strip it by locating '#' in the match, which only worked for
+ * '#' tags: with a capture-group regex an @mention kept its leading space
+ * inside the span and its prefix class came out as --char-20 instead of --at.
+ * The tag is now located by trimming, as the editor does, so both regex forms
+ * behave the same.
+ *
+ * Whatever the trim removes still has to be rendered, because the cursor
+ * advances past the whole match - hence the "loses no text" cases.
+ */
+import * as MarkdownIt from 'markdown-it';
+import tagPlugin from '../src/tagMarkdownItPlugin';
+import { defTagRegex } from '../src/utils';
+
+/** The multi-prefix example from the `Tag regex` setting description. */
+const LOOKBEHIND_MULTI = "(?<=^|\\s)([#@+]|\\/\\/)([^\\s#@'\",.()\\[\\]:;\\?\\\\]+)";
+/** The same intent written with a capture group, which includes the whitespace. */
+const CAPTURE_MULTI = '(^|\\s)([#@+]|\\/\\/)(\\S+)';
+/** A delimited form, whose match ends in whitespace. */
+const CAPTURE_TRAILING = '(^|\\s)#(\\w+)(\\s)';
+
+function render(src: string, tagRegex = '', excludeRegex = ''): string {
+  const md = new (MarkdownIt as any)({ html: true });
+  const mod = tagPlugin({} as any);
+  mod.plugin(md, {
+    settingValue: (key: string) =>
+      key === 'itags.tagRegex' ? tagRegex : key === 'itags.excludeRegex' ? excludeRegex : '',
+  });
+  return md.render(src);
+}
+
+/** [prefix suffix of the class list, span text] for each tag in the output. */
+function tags(html: string): [string, string][] {
+  return [...html.matchAll(/<span class="[^"]*itags-tag--(\S+?) [^"]*">([^<]*)<\/span>/g)]
+    .map(m => [m[1], m[2]] as [string, string]);
+}
+
+/**
+ * Visible text with all markup removed, to check nothing was dropped.
+ * Drops the injected style element first: its CSS is not markup, so tag
+ * stripping alone would leave the stylesheet in the "text".
+ */
+function textOf(html: string): string {
+  return html.replace(/<style>[\s\S]*?<\/style>/g, '').replace(/<[^>]*>/g, '');
+}
+
+describe('prefix splitting', () => {
+  it.each([
+    ['lookbehind', LOOKBEHIND_MULTI],
+    ['capture group', CAPTURE_MULTI],
+  ])('maps every prefix to its own class with a %s regex', (_name, regex) => {
+    expect(tags(render('a #tag @mention +proj //due end', regex))).toEqual([
+      ['hash', '#tag'],
+      ['at', '@mention'],
+      ['plus', '+proj'],
+      ['slash', '//due'],
+    ]);
+  });
+
+  it('does not put the captured whitespace inside the span', () => {
+    for (const [, text] of tags(render('a @mention here', CAPTURE_MULTI))) {
+      expect(text).toBe(text.trim());
+    }
+  });
+
+  it.each([
+    ['default', ''],
+    ['lookbehind', LOOKBEHIND_MULTI],
+    ['capture group', CAPTURE_MULTI],
+    ['capture group with trailing delimiter', CAPTURE_TRAILING],
+  ])('loses no text with a %s regex', (_name, regex) => {
+    const src = 'a #tag and @mention plus +proj end';
+    expect(textOf(render(src, regex)).trim()).toBe(src);
+  });
+
+  it('keeps the trailing delimiter outside the span', () => {
+    const html = render('a #tag end', CAPTURE_TRAILING);
+    expect(tags(html)).toEqual([['hash', '#tag']]);
+    expect(textOf(html).trim()).toBe('a #tag end');
+  });
+
+  it('still excludes tags matched by the exclude regex', () => {
+    const html = render('a #a1b2c3 and #keep', '', '#[a-fA-F0-9]{6}$');
+    expect(tags(html)).toEqual([['hash', '#keep']]);
+    expect(textOf(html).trim()).toBe('a #a1b2c3 and #keep');
+  });
+
+  it('shares the canonical default regex rather than a local copy', () => {
+    // foo#bar must not match, which both the old local copy and the canonical
+    // regex agree on - this pins that unifying them did not change matching.
+    expect(tags(render('foo#bar and #real', ''))).toEqual([['hash', '#real']]);
+    expect(defTagRegex.source).toContain('(?<=^|\\s)');
+  });
+});


### PR DESCRIPTION
## What

The Markdown preview split a regex match into prefix and tag using `fullMatch.indexOf('#')`. That only strips captured whitespace when the tag starts with `#`, so with a capture-group regex covering several prefixes an `@mention` rendered as:

```html
<span class="... itags-tag--char-20 ...">" @mention"</span>
```

— the leading space inside the span, and the prefix class derived from the space rather than the `@`. The tag is now located by trimming, as the editor already does.

Closes #42.

## Why it matters

#48 documented `.itags-tag--hash` / `--at` / `--plus` / `--slash` as the class contract on all three surfaces. The preview couldn't keep that promise for these regexes, so this is a direct contradiction of what we just shipped rather than a cosmetic detail.

## The trigger is narrower than #42 first said

I reproduced it before fixing, and the issue as filed blamed the wrong regex — it has been corrected.

| regex form | result for `@mention` |
|---|---|
| `(?<=^\|\s)([#@+]\|\/\/)(...)` — the documented example, lookbehind | `--at`, `"@mention"` — correct |
| `(^\|\s)([#@+])(\S+)` — capture group | `--char-20`, `" @mention"` — **bug** |
| `(^\|\s)#(\S+)` — capture group, `#` only | `--hash`, `"#tag"` — correct |

With a lookbehind, `match[0]` carries no leading whitespace, so `indexOf` returning `-1` is harmless. The bug needs the capture-group form *and* a non-`#` prefix.

## How

`tagBounds` moves from `cm6tagStyle.ts` to `utils.ts` — the preview needs the same trimming but cannot import from the CM6 script without pulling CodeMirror into its bundle. It is pure and dependency-free, so it sits beside `tagClasses` and `defaultTagCss`. Separate commit, no behaviour change.

One thing that needed care: the cursor advances past the whole match, so anything the trim removes must still be emitted or it disappears from the output. A delimited regex like `(^|\s)#(\w+)(\s)` would otherwise lose its trailing space. The remainder is now pushed as its own text token, and the "loses no text" cases pin that.

With the split no longer depending on the regex form, the plugin's local divergent copy of `defTagRegex` (capture-group) is replaced by the canonical one in `utils` (lookbehind). Both match the same text — `foo#bar` is excluded either way — and only the token boundaries differed, which are now handled uniformly.

## Verification

- 94 tests (10 new). Build clean.
- Defect injection: restoring `indexOf('#')` fails 3 of the new tests.
- Both regex forms are covered for every documented prefix, plus a delimited form whose match ends in whitespace.
- Exclude-regex behaviour is pinned, since the exclude branch also emits `tagPart`.

## Also folded in: the shared ReDoS gate

The preview was the last surface compiling user regexes without `isRegexSafe` — the indexer has always applied it, and the editor gained it in #41.

Not a hang risk, unlike the editor was. The preview's own loop advances `lastIndex` when a match is zero-length, so an empty-matching pattern terminates; verified against the real loop shape with `#?\w*`, `\w*`, `\b\w*` and `(?<=#)\w*`, all of which finish. What was missing is the backtracking gate — a catastrophic pattern renders every note slowly rather than never.

Kept as its own compile function rather than shared with the editor's. The two guard different hazards for different reasons, and merging them would mean an options bag so each caller could switch off the other's mechanism.

Removing the gate fails 2 of the new tests.