### PR TITLE
chore: drop dead imports and debug logging from cm6frontmatter (#47)

### DIFF
--- a/src/cm6frontmatter.ts
+++ b/src/cm6frontmatter.ts
@@ -1,17 +1,12 @@
-// src/cm6frontmatter.ts (only the relevant parts shown)
 import type { ContentScriptContext, MarkdownEditorContentScriptModule } from 'api/types';
-import joplin from 'api';
 
-// bundle only this:
+// Bundled, because Joplin does not provide it:
 import { yamlFrontmatter } from '@codemirror/lang-yaml';
 
-// shared with Joplin:
+// Provided by Joplin at runtime, so these stay webpack externals:
 import { language, Language, syntaxTree, LanguageSupport } from '@codemirror/language';
 import { Compartment, Prec, RangeSetBuilder } from '@codemirror/state';
 import { EditorView, Decoration, ViewPlugin, ViewUpdate } from '@codemirror/view';
-
-  import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
-  import { tags as t } from '@lezer/highlight';
 
 /* ---------- Dark/light detection (no .cm-dark required) ---------- */
 function parseRGB(input: string) {

--- a/src/cm6frontmatter.ts
+++ b/src/cm6frontmatter.ts
@@ -145,10 +145,6 @@ export default (_ctx: ContentScriptContext): MarkdownEditorContentScriptModule =
       view.dispatch({
         effects: fmLang.reconfigure(Prec.highest(support)),
       });
-
-      // Debug (singular facet):
-      const active = cm.editor.state.facet(language) as Language | null;
-      console.info('[fm] active language:', active?.name ?? '(none)');
     };
 
 


### PR DESCRIPTION
## What

Four dead imports and a leftover debug log in `src/cm6frontmatter.ts`.

Closes #47.

## Why the issue's premise was wrong

#47 guessed that the unused `import joplin from 'api'` was inflating the 42KB bundle. Measured: `cm6frontmatter.js` is **42836 bytes both before and after**, `joplin` appears 0 times in it, and `@lezer/highlight` still appears once after removing its import — reaching the bundle through `@codemirror/lang-yaml`'s own dependencies. Webpack was tree-shaking all of it.

The 42KB is `@codemirror/lang-yaml` plus `@lezer/yaml`, which this script genuinely needs and Joplin does not provide. The issue has been corrected.

So the value here is clarity, not size — which still leaves one item worth doing on its own merits.

## What was removed

| Import | Status |
|---|---|
| `joplin` from `api` | Never used, and **could not** work — content scripts run in the editor process without the plugin api. Removing it stops the file implying otherwise. |
| `HighlightStyle`, `syntaxHighlighting` | Imported, never referenced |
| `tags as t` from `@lezer/highlight` | Never referenced. The six apparent uses of `t` are a local `const t = doc.line(i).text` that shadows it |

Also: the stale header comment claiming the file shows "only the relevant parts", and `console.info('[fm] active language: ...')`, which ran on every editor open and again whenever another plugin reconfigured the language.

The import block now says which imports are bundled and which Joplin provides, since that is the non-obvious thing about it and the reason `lang-yaml` is the only one that costs anything.

## Verification

- Build clean, bundle byte-identical, zero new type errors, 98 tests pass.
- Nothing in this PR is reachable by the test suite — it is removal of unreferenced code, verified by grep and by the unchanged bundle rather than by assertions.

## Left alone deliberately

`frontmatterAsCode`'s update condition includes `u.transactions.length`, so decorations rebuild on **every** transaction including cursor movement — the same class of issue as the tree-identity rebuild fixed in #41. It is a performance question, not a correctness one, and changing it risks frontmatter highlighting in a file with no test coverage that I cannot exercise without the app. Worth its own issue and its own verification rather than riding along with a cleanup.