### PR TITLE
fix: stop indexing tags inside indented code blocks (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ After installing the plugin, check the commands listed under `Tag Navigator` in 
 - When the `Tag inheritance` setting is enabled (by default), tags are automatically inherited in three ways:
     1. **Outline/indentation inheritance**: Tags are inherited from parent items to their children based on indentation levels.
         - Example: If `#project/website` appears on a parent line, all indented child lines will also be tagged with `#project/website`
+        - Exception: four or more spaces of indent after a blank line, outside a list, is a Markdown code block. Those lines are skipped entirely when `Ignore code blocks` is on, so they neither carry nor inherit tags.
     2. **Heading inheritance**: Tags are inherited from headings to all content under that heading.
         - Example: If `## Meeting Notes #urgent` appears as a heading, all other *tagged lines* under that heading will also be tagged with `#urgent`
     3. **Top of the note inheritance**: Tags are inherited from the first 2 lines of the note.

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Every rendered tag carries four classes, on all three surfaces that display tags
 
 So `.itags-tag` styles tags everywhere, and the surface classes are there for when you want one surface to differ.
 
-Tags inside code are never styled on any of the three surfaces: code should look like code. The `Ignore code blocks` setting governs whether they are *indexed* - turn it off and tags in code blocks become searchable, but they still render as code.
+The `Ignore code blocks` setting governs whether tags inside code are *indexed*, not how they are styled. The editor and Markdown preview never style them. The search panel is not yet consistent here: it paints tags in any line it displays, including code lines pulled in as surrounding context, so a tag in a code block can appear styled there.
 
 The `Inline tags: Style` setting takes custom CSS and applies it to all three surfaces. **This is the only way to restyle tags on mobile**, where `userstyle.css` cannot be edited. On desktop you can use either that setting or `userstyle.css`.
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -88,6 +88,9 @@ export interface TagLineInfo {
  */
 export function parseTagsLines(text: string, tagSettings: TagSettings): TagLineInfo[] {
   let inCodeBlock = false;
+  let inIndentedCode = false;
+  let inList = false;
+  let prevLineBlank = true;  // the start of a note behaves like the line after a blank
   let isResultBlock = false;
   let isQueryBlock = false;
   let tagsMap = new Map<string, { lines: Set<number>; count: number }>();
@@ -102,6 +105,32 @@ export function parseTagsLines(text: string, tagSettings: TagSettings): TagLineI
     if (/^\s*```/.test(line)) {
       inCodeBlock = !inCodeBlock;
     }
+    // Track indented (four-space) code blocks. The fence test above cannot see
+    // them, so tags inside a pasted snippet were indexed: a shebang alone yields
+    // three, since nested tags split on '/'.
+    //
+    // List state is needed because an indented code block and a paragraph
+    // continuing a list item are identical line by line - a blank line, then the
+    // indent - and only the open list tells them apart. Tags on indented list
+    // content are ordinary usage, so the list has to win.
+    const lineIndent = line.match(/^\s*/)[0].length;
+    const lineIsBlank = /^\s*$/.test(line);
+    if (/^\s*([-*+]|\d+[.)])\s/.test(line)) {
+      inList = true;
+    } else if (!lineIsBlank && lineIndent === 0) {
+      inList = false;  // a paragraph at the margin closes the list
+    }
+    if (!inCodeBlock) {
+      if (inIndentedCode) {
+        // Blank lines stay inside the block; a line back at the margin ends it,
+        // and ends it before the skip below, so that line is still indexed.
+        if (!lineIsBlank && lineIndent < 4) { inIndentedCode = false; }
+      } else if (!lineIsBlank && lineIndent >= 4 && prevLineBlank && !inList) {
+        inIndentedCode = true;
+      }
+    }
+    prevLineBlank = lineIsBlank;
+
     if (line.match(resultsStart)) {
       isResultBlock = true;
     }
@@ -117,7 +146,7 @@ export function parseTagsLines(text: string, tagSettings: TagSettings): TagLineI
     const isEmptyLine = line.match(/^\s*$/);  // if we skip an empty line this means that inheritance isn't broken
     // Skip code blocks, front matter, result blocks, query blocks, and empty lines
     const isMatterBlock = matterRange && lineIndex >= matterRange.startLine && lineIndex <= matterRange.endLine;
-    if ((inCodeBlock && tagSettings.ignoreCodeBlocks) || isMatterBlock || isResultBlock || isQueryBlock || isEmptyLine) {
+    if (((inCodeBlock || inIndentedCode) && tagSettings.ignoreCodeBlocks) || isMatterBlock || isResultBlock || isQueryBlock || isEmptyLine) {
       return;
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,7 +120,11 @@ export function parseTagsLines(text: string, tagSettings: TagSettings): TagLineI
     // A thematic break matches a naive marker test - `* * *` is an asterisk and
     // a space - and would exempt the rest of the note from code detection.
     const isThematicBreak = /^ {0,3}([-*_])[ \t]*(\1[ \t]*){2,}$/.test(line);
-    if (!isThematicBreak && /^[ \t]*([-*+]|\d+[.)])[ \t]/.test(line)) {
+    // A marker only opens a list from outside an indented block. Otherwise a
+    // snippet whose first line is marker-shaped - numbered steps, a diff hunk -
+    // opens no block at all, and the flag then sticks and leaks the remainder.
+    const isMarker = !isThematicBreak && /^[ \t]*([-*+]|\d+[.)])[ \t]/.test(line);
+    if (isMarker && (lineIndent < 4 || inList)) {
       inList = true;
     } else if (!lineIsBlank && lineIndent === 0 && prevLineBlank) {
       // Only a new top-level block closes the list. A margin line straight

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -113,12 +113,21 @@ export function parseTagsLines(text: string, tagSettings: TagSettings): TagLineI
     // continuing a list item are identical line by line - a blank line, then the
     // indent - and only the open list tells them apart. Tags on indented list
     // content are ordinary usage, so the list has to win.
-    const lineIndent = line.match(/^\s*/)[0].length;
+    // Indent in columns, counting a tab as four, since a single tab opens an
+    // indented block just as four spaces do.
+    const lineIndent = line.match(/^[ \t]*/)[0].replace(/\t/g, '    ').length;
     const lineIsBlank = /^\s*$/.test(line);
-    if (/^\s*([-*+]|\d+[.)])\s/.test(line)) {
+    // A thematic break matches a naive marker test - `* * *` is an asterisk and
+    // a space - and would exempt the rest of the note from code detection.
+    const isThematicBreak = /^ {0,3}([-*_])[ \t]*(\1[ \t]*){2,}$/.test(line);
+    if (!isThematicBreak && /^[ \t]*([-*+]|\d+[.)])[ \t]/.test(line)) {
       inList = true;
-    } else if (!lineIsBlank && lineIndent === 0) {
-      inList = false;  // a paragraph at the margin closes the list
+    } else if (!lineIsBlank && lineIndent === 0 && prevLineBlank) {
+      // Only a new top-level block closes the list. A margin line straight
+      // after list content is a lazy continuation of that item's paragraph, so
+      // the list stays open and indented content below it is still list
+      // content - closing here would drop its tags.
+      inList = false;
     }
     if (!inCodeBlock) {
       if (inIndentedCode) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -342,9 +342,9 @@ export async function registerSettings(): Promise<void> {
       section: 'itags',
       public: true,
       label: 'Ignore code blocks',
-      description: 'Ignore inline tags in code blocks when indexing. ' +
-        'Turning this off makes them searchable, but they still render as code ' +
-        'rather than as tags in the editor, preview and search panel.',
+      description: 'Ignore inline tags in code blocks when indexing, both fenced ' +
+        'and indented (four spaces). Turning this off makes them searchable, but ' +
+        'they still render as code rather than as tags in the editor and preview.',
     },
     'itags.ignoreFrontMatter': {
       value: false,

--- a/tests/indentedCode.test.ts
+++ b/tests/indentedCode.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for indented (four-space) code blocks in the indexer, issue #46.
+ *
+ * The indexer's fence check is /^\s*```/, which cannot match an indented block,
+ * so tags inside one were indexed even with `Ignore code blocks` on. A pasted
+ * shell or C snippet therefore put junk in the tag list: a shebang alone yields
+ * three tags, because nested tags split on '/'.
+ *
+ * The hazard in fixing it is that an indented code block and a paragraph
+ * continuing a list item have the same shape line by line - a blank line, then
+ * four spaces - and differ only by whether a list is open. Tags on indented
+ * list content are core usage, so most of these cases exist to pin that they
+ * keep being indexed.
+ */
+import { parseTagsLines } from '../src/parser';
+import { TagSettings } from '../src/settings';
+import { defTagRegex } from '../src/utils';
+
+function settings(overrides: Partial<TagSettings> = {}): TagSettings {
+  return {
+    tagRegex: defTagRegex, excludeRegex: null, minCount: 1, colorTag: '#color=',
+    todayTag: '#today', monthTag: '#month', weekTag: '#week',
+    todayTagRegex: /(#today)([+-]?\d*)/g, monthTagRegex: /(#month)([+-]?\d*)/g,
+    weekTagRegex: /(#week)([+-]?\d*)/g, dateFormat: '#yyyy-MM-dd',
+    monthFormat: '#yyyy-MM', weekFormat: '#yyyy-MM-dd', weekStartDay: 0,
+    valueDelim: '=', spaceReplace: '_', tagPrefix: '', ignoreHtmlNotes: true,
+    ignoreCodeBlocks: true, ignoreFrontMatter: true, inheritTags: true,
+    nestedTags: true, fullNotebookPath: false, middleMatter: false,
+    includeNotebooks: [], excludeNotebooks: [], readBatchSize: 10,
+    ...overrides,
+  } as TagSettings;
+}
+
+const tags = (text: string, o: Partial<TagSettings> = {}) =>
+  parseTagsLines(text, settings(o)).map((t: any) => t.tag);
+
+describe('indented code blocks are not indexed', () => {
+  it('skips a tag in an indented block after a paragraph', () => {
+    expect(tags('para\n\n    #inindent\n')).toEqual([]);
+  });
+
+  it('skips a whole indented snippet, including its blank lines', () => {
+    expect(tags('shell:\n\n    #!/bin/bash\n\n    #define MAX\n')).toEqual([]);
+  });
+
+  it('resumes indexing after the block ends', () => {
+    expect(tags('para\n\n    #incode\n\nback to #prose\n')).toEqual(['#prose']);
+  });
+
+  it('leaves the realistic junk case with only the real tag', () => {
+    const note = [
+      'Here is some shell:', '',
+      '    #!/bin/bash',
+      '    # a normal comment',
+      '    grep -c "#TODO" file.txt',
+      '    #define MAX 10',
+      '    #include <stdio.h>',
+      '', 'and back to prose with #realtag',
+    ].join('\n');
+    expect(tags(note)).toEqual(['#realtag']);
+  });
+
+  it('indexes them again when the setting is off', () => {
+    expect(tags('para\n\n    #inindent\n', { ignoreCodeBlocks: false })).toEqual(['#inindent']);
+  });
+});
+
+describe('indented list content is still indexed', () => {
+  it('indexes a nested list item', () => {
+    expect(tags('- a\n    - #innested\n')).toContain('#innested');
+  });
+
+  it('indexes a deeply indented list item', () => {
+    expect(tags('- a\n  - b\n        - #indeep\n')).toContain('#indeep');
+  });
+
+  it('indexes a paragraph continuing a list item', () => {
+    expect(tags('- item\n\n    #incont\n')).toContain('#incont');
+  });
+
+  it('indexes a continuation under an ordered list item', () => {
+    expect(tags('1. item\n\n    #inordered\n')).toContain('#inordered');
+  });
+
+  it('indexes indented content under a list using * and + markers', () => {
+    expect(tags('* a\n\n    #instar\n')).toContain('#instar');
+    expect(tags('+ a\n\n    #inplus\n')).toContain('#inplus');
+  });
+
+  it('treats an indented line as code again once the list has ended', () => {
+    // A top-level paragraph closes the list, so what follows is code again.
+    expect(tags('- item\n\nparagraph\n\n    #aftercode\n')).toEqual([]);
+  });
+
+  it('indexes a lazy continuation with no blank line before it', () => {
+    // Indented code cannot interrupt a paragraph, so this is still prose.
+    expect(tags('some paragraph\n    #lazy\n')).toContain('#lazy');
+  });
+});
+
+describe('fenced blocks are unaffected', () => {
+  it('still skips a fenced block', () => {
+    expect(tags('para\n\n```\n#infence\n```\n')).toEqual([]);
+  });
+
+  it('still indexes a fenced block when the setting is off', () => {
+    expect(tags('para\n\n```\n#infence\n```\n', { ignoreCodeBlocks: false })).toEqual(['#infence']);
+  });
+
+  it('does not treat an indented fence as an indented code block', () => {
+    expect(tags('- item\n\n    ```\n    #innestedfence\n    ```\n')).toEqual([]);
+  });
+});

--- a/tests/indentedCode.test.ts
+++ b/tests/indentedCode.test.ts
@@ -120,6 +120,15 @@ describe('shapes that only look like list markers', () => {
     expect(tags('para\n\n***\n\n    #incode\n')).toEqual([]);
   });
 
+  it('does not let a marker-shaped first line cancel the block', () => {
+    // A pasted snippet whose first line looks like a marker - numbered steps,
+    // a diff hunk - would otherwise open no block, and the flag would then
+    // stick and leak the rest of it.
+    expect(tags('para\n\n    - #probe\n')).toEqual([]);
+    expect(tags('steps:\n\n    1. setup\n    #include <x.h> #probe\n')).toEqual([]);
+    expect(tags('diff:\n\n    - old #probe\n    + new\n')).toEqual([]);
+  });
+
   it('still treats a real list marker as a list', () => {
     expect(tags('- a\n\n    #inlist\n')).toContain('#inlist');
     expect(tags('* a\n\n    #inlist\n')).toContain('#inlist');

--- a/tests/indentedCode.test.ts
+++ b/tests/indentedCode.test.ts
@@ -92,9 +92,47 @@ describe('indented list content is still indexed', () => {
     expect(tags('- item\n\nparagraph\n\n    #aftercode\n')).toEqual([]);
   });
 
+  it('keeps the list open across a lazy continuation at the margin', () => {
+    // CommonMark: a margin line straight after list content continues that
+    // item's paragraph, so the list is still open and the indented block below
+    // is list content, not code. Closing the list here loses the tag.
+    expect(tags('- item\nlazy continuation\n\n    #tag\n')).toContain('#tag');
+    expect(tags('- a\n- b\ntext at margin\n\n    #tag\n')).toContain('#tag');
+  });
+
+  it('closes the list at a new top-level block, not at a continuation', () => {
+    // A margin line *after a blank* starts a new block and does close the list.
+    expect(tags('- item\n\nparagraph\n\n    #aftercode\n')).toEqual([]);
+  });
+
   it('indexes a lazy continuation with no blank line before it', () => {
     // Indented code cannot interrupt a paragraph, so this is still prose.
     expect(tags('some paragraph\n    #lazy\n')).toContain('#lazy');
+  });
+});
+
+describe('shapes that only look like list markers', () => {
+  it('does not mistake a thematic break for a list', () => {
+    // `* * *` and `- - -` match a naive marker test, which would exempt the
+    // rest of the note from code detection.
+    expect(tags('para\n\n* * *\n\n    #incode\n')).toEqual([]);
+    expect(tags('para\n\n- - -\n\n    #incode\n')).toEqual([]);
+    expect(tags('para\n\n***\n\n    #incode\n')).toEqual([]);
+  });
+
+  it('still treats a real list marker as a list', () => {
+    expect(tags('- a\n\n    #inlist\n')).toContain('#inlist');
+    expect(tags('* a\n\n    #inlist\n')).toContain('#inlist');
+  });
+});
+
+describe('tab indentation', () => {
+  it('treats a tab as four columns, so tab-indented blocks are code', () => {
+    expect(tags('para\n\n\t#tabbed\n')).toEqual([]);
+  });
+
+  it('still indexes tab-indented list content', () => {
+    expect(tags('- item\n\n\t#tabbed\n')).toContain('#tabbed');
   });
 });
 


### PR DESCRIPTION
## What

The indexer's only code test was the fence regex `/^\s*```/`, which cannot match a four-space indented block. Tags inside a pasted snippet were therefore indexed, reaching the tag list and autocomplete.

Measured on one note containing an indented shell/C block:

```
before  ["#!", "#!/bin", "#!/bin/bash", "#define", "#include", "#realtag"]
after   ["#realtag"]
```

Three of those came from a single shebang, since nested tags split on `/`. Worth noting `# a normal comment` was never affected - the tag regex requires a non-space after the `#` - so the junk is specifically shebangs, preprocessor directives and `#TODO`-style tokens.

Closes the indexer half of #46; see below for what it does not close.

## Why this was the risky half of the issue

An indented code block and a paragraph continuing a list item are **identical line by line**: a blank line, then four spaces of indent. Only an open list tells them apart, and the parser had no list state - it tracked raw `indentLevel` for tag inheritance and nothing else.

Tags on indented list content are ordinary usage for this plugin, so getting this wrong would silently stop indexing them. That is why the issue originally recorded a recommendation *against* doing it; the junk-tag measurement above is what reversed it.

## How it is kept narrow

Three conditions, each with a reason:

- **an open list wins.** A marker line (`-`, `*`, `+`, `1.`, `1)`) opens a list; a non-blank line back at the margin closes it. While a list is open, indented content is never treated as code.
- **a block starts only after a blank line**, so an indented line continuing a paragraph stays prose. That matches CommonMark's rule that indented code cannot interrupt a paragraph.
- **the block ends before the skip check**, so the line that ends it is still indexed rather than swallowed.

Blank lines inside a block do not end it, so a snippet with internal spacing is skipped as one unit.

## Verification

Written test-first, which is the substance of the verification here:

- With the 15 tests in place and the parser **unchanged**, exactly the 5 indented-code cases failed and all 10 list, fence and lazy-continuation cases passed. That pins that this change touches only the intended behaviour, rather than resting on my reading of the parser.
- The full suite is green at 113, including the 18 pre-existing `nestedTags` tests, which cover indented list structure and tag inheritance and are the real regression check.
- Both guards are load-bearing: dropping the list guard fails 3 tests, dropping the blank-line guard fails 1.
- Zero new type errors, build clean.

## What this does *not* close in #46

This PR originally claimed the render half of #46 became unreachable once the tags were no longer indexed. **Review falsified that**, and the claim is withdrawn.

The panel never consults the index when deciding what to paint. Context expansion pulls neighbouring lines from the raw note body by proximity (`search.ts:488-499`), so code lines reach `replaceOutsideBackticks` regardless of indexing — at default settings, since `itags.contextExpansionStep` is 2. Worse, whether they render as painted prose or as literal escaped `<span>` markup depends on where the expanded window happens to start, because `normalizeIndentation` may or may not strip the indent before `md.render` sees it.

Filed as #52 with the measured output. This PR therefore closes only the indexer half; #46 is annotated and #52 carries the render half.

## Not folded in

`parseLinkLines` (`parser.ts:570`) has the same fence-only check for its `ignoreCodeBlocks` argument, so links inside an indented block are still extracted. Different function and different feature, so it belongs in its own change - happy to file it.

## Review round 1

Reviewed by a separate isolated session against `ba37819...6472fb8`. It found one genuine regression and two mechanism defects; all three came from rendering shapes through the parser rather than reading it, which is how they got past my own tests.

**Tag loss, at default settings** (`4b269ff`). The list was closed by any non-blank line at the margin, but CommonMark treats a margin line straight after list content as a lazy continuation, keeping the list open. So this lost a tag:



Base indexed `#cont`; the reviewed head returned `[]`. Only a margin line *after a blank* closes the list now. The description's claim that "a non-blank line back at the margin closes it" described a rule that loses data.

**Thematic breaks read as list markers** (`4b269ff`). `* * *` is an asterisk and a space, so it matched the marker test and left the rest of the note exempt until the next margin line — silently disabling the fix in any note using `* * *` or `- - -` as a separator.

**Tabs counted as one column** (`4b269ff`). A tab-indented block never reached four columns. Counted as four now, in a measure local to this check so the `indentLevel` driving tag inheritance is untouched.

**Marker-shaped first line cancelled the block** (`bf8a924`). A snippet whose first line looked like a marker opened no block, and the flag then stuck and leaked the rest: `steps:` / blank / `    1. setup` / `    #include <x.h> #probe` yielded `["#include", "#probe"]`. A marker now opens a list only from outside an indented block, unless one is already open.

Each guard is defect-injected: dropping any one of the four fails exactly one test, and dropping the fix entirely fails eight. Suite green at 120.

Two corrections to the record rather than the code. The README line claiming tags in code are never styled on any surface was inaccurate when written and is fixed in `bf8a924`. And the test-first attribution in the first commit was off by one in each direction: `indexes them again when the setting is off` sits in the indented-code group but passes on base, and `treats an indented line as code again once the list has ended` sits in the list group but fails on base. The 5/10 counts were right; the grouping was not.

## Known and accepted

`# H` followed by an indented line is still indexed, where CommonMark says code — the blank-line guard is applied after every line rather than only after paragraphs. Under-skips, so it leaves junk rather than losing tags, and closing it means modelling which block types a code block may follow. On record rather than fixed.

## Review round 1

Reviewed by a separate isolated session against `ba37819...6472fb8`. It found one genuine regression and three mechanism defects; all came from rendering shapes through the parser rather than reading it, which is how they got past my own tests.

**Tag loss, at default settings** (`4b269ff`). The list was closed by any non-blank line at the margin, but CommonMark treats a margin line straight after list content as a lazy continuation, keeping the list open. So a list item's second paragraph was skipped as code and its tag lost: `- item` / `lazy line` / blank / four-space `#cont` gave `["#cont"]` on base and `[]` on the reviewed head. Only a margin line *after a blank* closes the list now. The description's claim that "a non-blank line back at the margin closes it" described a rule that loses data.

**Thematic breaks read as list markers** (`4b269ff`). `* * *` is an asterisk and a space, so it matched the marker test and left the rest of the note exempt until the next margin line, silently disabling the fix in any note using `* * *` or `- - -` as a separator.

**Tabs counted as one column** (`4b269ff`). A tab-indented block never reached four columns. Counted as four now, in a measure local to this check so the `indentLevel` driving tag inheritance is untouched.

**Marker-shaped first line cancelled the block** (`bf8a924`). A snippet whose first line looked like a marker opened no block, and the flag then stuck and leaked the rest: `steps:` / blank / four-space `1. setup` / four-space `#include <x.h> #probe` yielded `["#include", "#probe"]`. A marker now opens a list only from outside an indented block, unless one is already open.

Each guard is defect-injected: dropping any one of the four fails exactly one test, and dropping the fix entirely fails eight. Suite green at 120.

Two corrections to the record rather than the code. The README line claiming tags in code are never styled on any surface was inaccurate when written, and is fixed in `bf8a924`. And the test-first attribution in the first commit was off by one in each direction: "indexes them again when the setting is off" sits in the indented-code group but passes on base, and "treats an indented line as code again once the list has ended" sits in the list group but fails on base. The 5/10 counts were right; the grouping was not.

## Verified against an independent CommonMark oracle

The reviewer built a harness that renders each input with the repo's own `markdown-it` and asks whether the probe tag lands inside `<pre><code>`, then compares that to the indexer's decision. Re-run against the fixed head:

**22 of 24 cases agree with CommonMark, and there are zero over-skips** — no input where the indexer calls something code that CommonMark calls text. That is the direction that loses tags, and it is now empty across the oracle, including the lazy-continuation shape that was the regression.

## Known and accepted

Both remaining oracle disagreements under-skip, so they leave junk rather than losing tags:

- `- item` / blank / eight-space `#tag` — CommonMark reads eight spaces under a two-column marker as a code block *inside* the list item. Catching it means tracking each item's content indent, i.e. marker width, rather than an absolute column.
- `# H` / four-space `#tag` with no blank between — the blank-line guard is applied after every line rather than only after paragraphs. Catching it means modelling which block types a code block may follow.

Both are on record rather than fixed. The approximation's failure direction is the safe one.

## Answering the reviewer's question

The lazy-continuation shape was not considered and accepted — it was a genuine miss. My tests covered the hazard I had identified (indent inside lists) and every "still indexed" case opened with a real list marker, which is exactly why that shape slipped through.
