### PR TITLE
feat: highlight inline checkboxes in the Markdown editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Draw the checkboxes Joplin renders for `[ ]` and `[x]` as text markers too, so t
 }
 
 .cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]::after {
-	content: " [ ]";
+	content: "[ ]";
 }
 
 .cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]:checked {
@@ -590,14 +590,20 @@ Draw the checkboxes Joplin renders for `[ ]` and `[x]` as text markers too, so t
 }
 
 .cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]:checked::after {
-	content: " [x]";
+	content: "[x]";
 }
 
 /* Joplin's checkbox stands in for the list bullet as well, so hide the bullet
-   on the lines it does not replace. With the space each marker leads with, the
-   six states then start at the same column. */
+   on the lines it does not replace. */
 .cm-editor .cm-line:has(.itags-editor-checkbox) .cm-bullet-list-marker {
 	display: none;
+}
+
+/* The other states keep the space that follows their bullet in the text, so
+   the checkbox needs one too. It goes on the container, not in the monospace
+   marker, so that both spaces are the same width. */
+.cm-editor .cm-ext-checkbox-toggle::before {
+	content: " ";
 }
 
 /* Joplin reads [@] and its siblings as links, and underlines them. */
@@ -606,7 +612,7 @@ Draw the checkboxes Joplin renders for `[ ]` and `[x]` as text markers too, so t
 }
 ```
 
-The bullet rule needs `:has()`, which desktop Joplin and iOS 15.4 or later have, and the alignment assumes the editor font is monospace, as it is by default. Where either does not hold the markers still get their colour, they just do not line up.
+The bullet rule needs `:has()`, which desktop Joplin and iOS 15.4 or later have. Without it the markers still get their colour, they just do not line up.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This plugin adds inline tag support (such as #inline-tag) to [Joplin](https://jo
     - Click a global tag to search for it, Cmd/Ctrl+click to add it to the current query, or Shift+click to insert it into the editor.
 4. It can convert your existing inline tags to native Joplin tags, so that they are accessible using Joplin's built-in tag search.
 5. It can convert your existing native Joplin tags to inline tags, so that they are accessible using inline tag search (this plugin). ([tips](#converting-joplin-tags))
-6. It renders inline tags and front matter in both the Markdown preview and the Markdown editor. ([tips](#styling-inline-tags))
+6. It renders inline tags and front matter in both the Markdown preview and the Markdown editor. ([tips](#styling-inline-tags-and-checkboxes))
 
 After installing the plugin, check the commands listed under `Tag Navigator` in the `Tools` menu, as well as the corresponding settings section.
 
@@ -106,7 +106,7 @@ After installing the plugin, check the commands listed under `Tag Navigator` in 
 - [Filtering results](#filtering-results)
 - [Context expansion](#context-expansion)
 - [Colour tags](#colour-tags)
-- [Styling inline tags](#styling-inline-tags)
+- [Styling inline tags and checkboxes](#styling-inline-tags-and-checkboxes)
 
 ### Advanced
 - [Inline TODOs](#inline-todos)
@@ -484,21 +484,24 @@ Context expansion lets you reveal surrounding lines around search results to see
 
 ![colour tags](img/tag-navigator-colours.png)
 
-### Styling inline tags
+### Styling inline tags and checkboxes
 
-Tags are displayed on three surfaces: the search panel, the Markdown preview and the Markdown editor. Every rendered tag carries a shared class and a surface-specific one, each in a plain and a per-prefix form:
+Tags are displayed on three surfaces: the search panel, the Markdown preview and the Markdown editor. Every rendered tag, and every task marker, carries a shared class and a surface-specific one, each in a plain form and one per prefix or state:
 
 | Class | Matches |
 | ----- | ------- |
 | `itags-tag`, `itags-tag--hash` / `--at` / `--plus` / `--slash` | every surface |
 | `itags-search-renderedTag` (panel, preview), `itags-editor-tag` (editor), each with the same prefix suffixes | one surface |
+| `itags-checkbox`, `itags-checkbox--open` / `--ongoing` / `--in-question` / `--blocked` / `--done` / `--obsolete` | task markers, panel and editor |
 
-The `Inline tags: Style` setting takes custom CSS and applies it to all three. **This is the only way to restyle tags on mobile**, where `userstyle.css` cannot be edited. Your rules override the bundled default without needing `!important`.
+The `Inline tags and checkboxes: Style` setting takes custom CSS and applies it to all three. **This is the only way to restyle tags on mobile**, where `userstyle.css` cannot be edited. Your rules override the bundled default without needing `!important`.
+
+`Inline checkboxes: Highlight in editor` colours the six task states in the editor. Joplin draws `[ ]` and `[x]` as checkboxes of its own, so those two keep their usual look and the other four, which Joplin does not recognise, get the state colour.
 
 `Search: Panel style` and `Navigation: Panel style` style those panels as a whole rather than tags.
 
 <details>
-<summary>CSS examples for tag styling</summary>
+<summary>CSS examples for tag and checkbox styling</summary>
 
 Style every tag on every surface:
 
@@ -539,6 +542,63 @@ Style one surface differently from the others. Avoid `display: inline-block` in 
 	border-bottom: 2px solid #7698b3;
 }
 ```
+
+Recolour a task state in the panel and the editor at once:
+
+```css
+.itags-checkbox--blocked {
+	color: #e22d2d;
+}
+```
+
+In the panel the marker is a coloured square, so set `background-color` there:
+
+```css
+.itags-search-checkbox--blocked {
+	background-color: #e22d2d;
+}
+```
+
+Draw the checkboxes Joplin renders for `[ ]` and `[x]` as text markers too, so that all six states match. This one reaches into Joplin's own editor markup, so it may need adjusting after a Joplin update, and it is left to you rather than bundled for that reason. The checkboxes stay clickable:
+
+```css
+.cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"] {
+	appearance: none;
+	-webkit-appearance: none;
+	width: auto;
+	height: auto;
+	margin: 0;
+	font-family: monospace;
+	font-weight: bold;
+	color: #4178be;
+}
+
+.cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]::after {
+	content: " [ ]";
+}
+
+.cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]:checked {
+	color: #64a073;
+}
+
+.cm-editor .cm-ext-checkbox-toggle > input[type="checkbox"]:checked::after {
+	content: " [x]";
+}
+
+/* Joplin's checkbox stands in for the list bullet as well, so hide the bullet
+   on the lines it does not replace. With the space each marker leads with, the
+   six states then start at the same column. */
+.cm-editor .cm-line:has(.itags-editor-checkbox) .cm-bullet-list-marker {
+	display: none;
+}
+
+/* Joplin reads [@] and its siblings as links, and underlines them. */
+.cm-editor .itags-editor-checkbox * {
+	text-decoration: none;
+}
+```
+
+The bullet rule needs `:has()`, which desktop Joplin and iOS 15.4 or later have, and the alignment assumes the editor font is monospace, as it is by default. Where either does not hold the markers still get their colour, they just do not line up.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,14 @@ Style one surface differently from the others. Avoid `display: inline-block` in 
 }
 ```
 
+Fonts in the editor need one extra step. Joplin resets `font-family` on every span there, which outranks a bare class, so lead with `span`:
+
+```css
+span.itags-checkbox {
+	font-family: sans-serif;
+}
+```
+
 Recolour a task state in the panel and the editor at once:
 
 ```css

--- a/src/cm6tagStyle.ts
+++ b/src/cm6tagStyle.ts
@@ -4,22 +4,31 @@ import type { EditorState } from '@codemirror/state';
 import {
   Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate,
 } from '@codemirror/view';
-import { defaultTagCss, defTagRegex, isRegexSafe, tagBounds, tagClasses } from './utils';
+import {
+  checkboxClasses, checkboxMarkerRegex, checkboxStateFor, defaultCheckboxCss, defaultTagCss,
+  defTagRegex, isRegexSafe, tagBounds, tagClasses,
+} from './utils';
 
 const TAG_CLASS = 'itags-editor-tag';
+const CHECKBOX_CLASS = 'itags-editor-checkbox';
 const STYLE_ELEMENT_ID = 'itags-editor-tag-style';
 
 /**
- * Default tag appearance for the editor, from the definition shared with the
- * panel and preview. Omits the block layout those two use, since inline-block
- * and vertical margins disturb caret placement and line height here.
+ * Default appearance for the editor, from the definitions shared with the panel
+ * and preview. Tags omit the block layout those two use, since inline-block and
+ * vertical margins disturb caret placement and line height here. Both are
+ * injected whichever highlighter is on, since a class nothing carries costs
+ * nothing.
  */
-const DEFAULT_CSS = defaultTagCss(TAG_CLASS);
+const DEFAULT_CSS = `${defaultTagCss(TAG_CLASS)}\n${defaultCheckboxCss(CHECKBOX_CLASS)}`;
 
-type TagStyleSettings = {
+/** What the plugin's settings say the editor should paint, and how. */
+type EditorStyleSettings = {
   tagRegex: string;
   excludeRegex: string;
   css: string;
+  tags: boolean;
+  checkboxes: string;
 };
 
 /**
@@ -129,7 +138,7 @@ export function inCodeContext(state: EditorState, pos: number): boolean {
 }
 
 /** Where a match should be painted, as offsets within the matched text. */
-type Marker = { start: number; end: number; className: string };
+export type Marker = { start: number; end: number; className: string };
 
 /**
  * A view plugin that paints one class per regex match in the visible ranges.
@@ -194,7 +203,7 @@ function markerPlugin(regexp: RegExp, locate: (match: RegExpExecArray) => Marker
 }
 
 /** Paints inline tags, minus any the exclude pattern rejects. */
-function tagPlugin(settings: TagStyleSettings) {
+function tagPlugin(settings: EditorStyleSettings) {
   const excludeRegex = compileExcludeRegex(settings.excludeRegex);
 
   return markerPlugin(compileTagRegex(settings.tagRegex), match => {
@@ -210,13 +219,40 @@ function tagPlugin(settings: TagStyleSettings) {
   });
 }
 
+/**
+ * Paints the marker of a task in one of the six states, and only the marker.
+ *
+ * Joplin replaces the bullet of a list item, and the [ ] or [x] of a task, with
+ * widgets of its own while its `Render markup in editor` setting is on, which
+ * is the default. A decoration on those two states is then inert, and one
+ * spanning the bullet would paint a range that is no longer there, so the
+ * decoration stops at the brackets. The other four states are invisible to
+ * Joplin's Markdown parser, which is why they are the ones this shows.
+ */
+export function checkboxMarker(match: RegExpExecArray): Marker | null {
+  const state = checkboxStateFor(match[1]);
+  if (!state) { return null; }
+
+  return {
+    start: match[0].indexOf('['),
+    end: match[0].length,
+    className: checkboxClasses(state, CHECKBOX_CLASS),
+  };
+}
+
+function checkboxPlugin() {
+  return markerPlugin(checkboxMarkerRegex(), checkboxMarker);
+}
+
 export default (context: ContentScriptContext): MarkdownEditorContentScriptModule => ({
   plugin: (editorControl: CodeMirrorControl) => {
     if (!editorControl.cm6) { return; }
 
     // Settings arrive over postMessage, so the extension is added once they land.
     void (async () => {
-      let settings: TagStyleSettings = { tagRegex: '', excludeRegex: '', css: '' };
+      let settings: EditorStyleSettings = {
+        tagRegex: '', excludeRegex: '', css: '', tags: true, checkboxes: 'markers',
+      };
       try {
         settings = await context.postMessage({ name: 'getTagStyleSettings' }) ?? settings;
       } catch (error) {
@@ -224,7 +260,8 @@ export default (context: ContentScriptContext): MarkdownEditorContentScriptModul
       }
 
       applyStyle(settings.css);
-      editorControl.addExtension(tagPlugin(settings));
+      if (settings.tags) { editorControl.addExtension(tagPlugin(settings)); }
+      if (settings.checkboxes !== 'off') { editorControl.addExtension(checkboxPlugin()); }
     })();
   },
 });

--- a/src/cm6tagStyle.ts
+++ b/src/cm6tagStyle.ts
@@ -128,44 +128,44 @@ export function inCodeContext(state: EditorState, pos: number): boolean {
   return false;
 }
 
+/** Where a match should be painted, as offsets within the matched text. */
+type Marker = { start: number; end: number; className: string };
+
 /**
- * Builds the decorator that marks up tags in the visible ranges.
+ * A view plugin that paints one class per regex match in the visible ranges.
  *
- * No `boundary` option: it is only an optimisation of MatchDecorator's patch
- * path, and it requires a character that can never occur inside a match, which
- * whitespace cannot guarantee once a user supplies the capture-group form.
- * Without it that path re-scans the whole changed line against the real line
- * text, which is correct for every pattern shape. It matters little either way,
- * since the view plugin below rebuilds the viewport on every doc change.
+ * Callers say what to match and what to call it; this owns the rest, so a
+ * second kind of match costs a regex and a locate function. Matches inside
+ * code are skipped, since a marker there is text rather than a marker, the way
+ * the panel (replaceOutsideBackticks) and the preview (markSkippableTextTokens)
+ * skip code too.
+ *
+ * No `boundary` option on the decorator: it is only an optimisation of
+ * MatchDecorator's patch path, and it requires a character that can never
+ * occur inside a match, which whitespace cannot guarantee once a user supplies
+ * the capture-group form of the tag regex. Without it that path re-scans the
+ * whole changed line against the real line text, which is correct for every
+ * pattern shape. It matters little either way, since the plugin rebuilds the
+ * viewport on every doc change.
+ *
+ * @param regexp What to look for. Must be global, and a fresh instance, since
+ *   MatchDecorator mutates lastIndex.
+ * @param locate Where within a match to paint, and with which classes, or null
+ *   to paint nothing.
  */
-function tagDecorator(tagRegex: RegExp, excludeRegex: RegExp | null): MatchDecorator {
-  return new MatchDecorator({
-    regexp: tagRegex,
+function markerPlugin(regexp: RegExp, locate: (match: RegExpExecArray) => Marker | null) {
+  const decorator = new MatchDecorator({
+    regexp,
     decorate: (add, from, _to, match, view) => {
-      const { tag, lead } = tagBounds(match[0]);
-      if (!tag) { return; }
+      const marker = locate(match);
+      if (!marker) { return; }
 
-      if (excludeRegex) {
-        excludeRegex.lastIndex = 0;
-        if (excludeRegex.test(tag)) { return; }
-      }
-
-      const start = from + lead;
+      const start = from + marker.start;
       if (inCodeContext(view.state, start)) { return; }
 
-      add(start, start + tag.length, Decoration.mark({
-        class: tagClasses(tag, TAG_CLASS),
-      }));
+      add(start, from + marker.end, Decoration.mark({ class: marker.className }));
     },
   });
-}
-
-/** View plugin that keeps tag decorations in step with edits, scrolling and parsing. */
-function tagStylePlugin(settings: TagStyleSettings) {
-  const decorator = tagDecorator(
-    compileTagRegex(settings.tagRegex),
-    compileExcludeRegex(settings.excludeRegex),
-  );
 
   return ViewPlugin.fromClass(class {
     decorations: DecorationSet;
@@ -193,6 +193,23 @@ function tagStylePlugin(settings: TagStyleSettings) {
   }, { decorations: value => value.decorations });
 }
 
+/** Paints inline tags, minus any the exclude pattern rejects. */
+function tagPlugin(settings: TagStyleSettings) {
+  const excludeRegex = compileExcludeRegex(settings.excludeRegex);
+
+  return markerPlugin(compileTagRegex(settings.tagRegex), match => {
+    const { tag, lead } = tagBounds(match[0]);
+    if (!tag) { return null; }
+
+    if (excludeRegex) {
+      excludeRegex.lastIndex = 0;
+      if (excludeRegex.test(tag)) { return null; }
+    }
+
+    return { start: lead, end: lead + tag.length, className: tagClasses(tag, TAG_CLASS) };
+  });
+}
+
 export default (context: ContentScriptContext): MarkdownEditorContentScriptModule => ({
   plugin: (editorControl: CodeMirrorControl) => {
     if (!editorControl.cm6) { return; }
@@ -207,7 +224,7 @@ export default (context: ContentScriptContext): MarkdownEditorContentScriptModul
       }
 
       applyStyle(settings.css);
-      editorControl.addExtension(tagStylePlugin(settings));
+      editorControl.addExtension(tagPlugin(settings));
     })();
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,19 +128,26 @@ joplin.plugins.register({
         './tagMarkdownItPlugin.js',
       );
     }
-    if (await joplin.settings.value('itags.highlightTags')) {
+    const highlightTags = await joplin.settings.value('itags.highlightTags');
+    const highlightCheckboxes = await joplin.settings.value('itags.highlightCheckboxes');
+    if (highlightTags || highlightCheckboxes !== 'off') {
       // Handler before registration: an editor mounting between the two awaits
       // would post getTagStyleSettings into the void, and the content script
       // would silently fall back to the default regex and no user CSS.
       await joplin.contentScripts.onMessage('itagsTagStyle', async (message: any) => {
         if (message?.name !== 'getTagStyleSettings') { return null; }
+        // Read on every request, so a setting change reaches the next editor
+        // to mount without a restart. Only the registration above needs one.
         const settings = await joplin.settings.values([
           'itags.tagRegex', 'itags.excludeRegex', 'itags.tagStyle',
+          'itags.highlightTags', 'itags.highlightCheckboxes',
         ]);
         return {
           tagRegex: settings['itags.tagRegex'] as string,
           excludeRegex: settings['itags.excludeRegex'] as string,
           css: settings['itags.tagStyle'] as string,
+          tags: settings['itags.highlightTags'] as boolean,
+          checkboxes: settings['itags.highlightCheckboxes'] as string,
         };
       });
       await joplin.contentScripts.register(

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -4,7 +4,9 @@ import * as markdownItMark from 'markdown-it-mark';
 import * as markdownItTaskLists from 'markdown-it-task-lists';
 import * as prism from './prism.js';
 import { TagSettings, getTagSettings, queryEnd, queryStart, getResultSettings, getStandardGroupingKeys, DEFAULT_QUERY_MODE } from './settings';
-import { defaultTagCss, escapeRegex, tagClasses } from './utils';
+import {
+  CHECKBOX_STATES, checkboxClasses, checkboxLineRegex, defaultTagCss, escapeRegex, tagClasses,
+} from './utils';
 import { GroupedResult, Query, QueryRecord, runSearch, sortResults } from './search';
 import { noteIdRegex } from './parser';
 import { NoteDatabase, processNote } from './db';
@@ -31,12 +33,6 @@ const md = new MarkdownIt({
 export const REGEX = {
   findQuery: new RegExp(`[\n]*${queryStart}([\\s\\S]*?)${queryEnd}`),
   wikiLink: /\[\[([^\]]+)\]\]/g,
-  xitOpen: /(^[\s]*)- \[ \] (.*)$/gm,
-  xitDone: /(^[\s]*)- \[[xX]\] (.*)$/gm,
-  xitOngoing: /(^[\s]*)- \[@\] (.*)$/gm,
-  xitObsolete: /(^[\s]*)- \[~\] (.*)$/gm,
-  xitInQuestion: /(^[\s]*)- \[\?\] (.*)$/gm,
-  xitBlocked: /(^[\s]*)- \[!\] (.*)$/gm,
   codeBlock: /(```[^`]*```)/g,
   backtickContent: /(`[^`]*`)/,
   heading: /^(#{1,6})\s+(.*)$/,
@@ -44,6 +40,20 @@ export const REGEX = {
   checkboxState: /^(\s*- \[)[x\s@\?!~](\])/g,
   contextMarker: /\u200B\u2060/g,
   coreMarker: /\u200B\u2061/g,
+};
+
+/**
+ * The class name the panel has always given each task state, kept alongside the
+ * shared ones. The panel's own script reads these to decide what a click means,
+ * and users style them from `Search: Panel style`.
+ */
+const LEGACY_CHECKBOX_CLASS: Record<string, string> = {
+  'open': 'xitOpen',
+  'ongoing': 'xitOngoing',
+  'in-question': 'xitInQuestion',
+  'blocked': 'xitBlocked',
+  'done': 'xitDone',
+  'obsolete': 'xitObsolete',
 };
 
 // QueryRecord is defined in search.ts and re-exported here for backward compatibility
@@ -790,6 +800,28 @@ export async function updatePanelNoteState(panel: string, savedNoteState: { [key
 }
 
 /**
+ * Rewrites every task line into the panel's checkbox markup.
+ *
+ * The square carries the shared classes, so one CSS rule reaches the panel and
+ * the editor at once, and the state's long-standing class, which the panel's
+ * own script reads on a click. The text after the marker keeps its own class,
+ * since the panel dims and strikes through a whole line where the editor only
+ * colours the marker.
+ *
+ * @param text The result text, before Markdown rendering
+ */
+export function renderCheckboxes(text: string): string {
+  for (const state of CHECKBOX_STATES) {
+    const legacy = LEGACY_CHECKBOX_CLASS[state.key];
+    text = text.replace(checkboxLineRegex(state),
+      `$1- <span class="${checkboxClasses(state, 'itags-search-checkbox')} ${legacy}" ` +
+      `data-checked="${state.key === 'done'}"></span>` +
+      `<span class="itags-search-${legacy}">$2</span>\n`);
+  }
+  return text;
+}
+
+/**
  * Renders markdown content to HTML with special handling for tags and checkboxes
  * @param groupedResults - Search results grouped by note
  * @param tagRegex - Regular expression for matching tags
@@ -823,13 +855,7 @@ function renderHTML(groupedResults: GroupedResult[], tagRegex: RegExp, resultMar
     processedSection = processedSection
       .replace(REGEX.wikiLink, '<a href="$1">$1</a>');
     if (colorTodos) {
-      processedSection = processedSection
-        .replace(REGEX.xitOpen, '$1- <span class="itags-search-checkbox xitOpen" data-checked="false"></span><span class="itags-search-xitOpen">$2</span>\n')
-        .replace(REGEX.xitDone, '$1- <span class="itags-search-checkbox xitDone" data-checked="true"></span><span class="itags-search-xitDone">$2</span>\n')
-        .replace(REGEX.xitOngoing, '$1- <span class="itags-search-checkbox xitOngoing" data-checked="false"></span><span class="itags-search-xitOngoing">$2</span>\n')
-        .replace(REGEX.xitObsolete, '$1- <span class="itags-search-checkbox xitObsolete" data-checked="false"></span><span class="itags-search-xitObsolete">$2</span>\n')
-        .replace(REGEX.xitInQuestion, '$1- <span class="itags-search-checkbox xitInQuestion" data-checked="false"></span><span class="itags-search-xitInQuestion">$2</span>\n')
-        .replace(REGEX.xitBlocked, '$1- <span class="itags-search-checkbox xitBlocked" data-checked="false"></span><span class="itags-search-xitBlocked">$2</span>\n');
+      processedSection = renderCheckboxes(processedSection);
     }
     let html = md.render(processedSection);
     // Replace markers (Unicode) with HTML spans for CSS styling

--- a/src/searchPanel.ts
+++ b/src/searchPanel.ts
@@ -800,23 +800,32 @@ export async function updatePanelNoteState(panel: string, savedNoteState: { [key
 }
 
 /**
- * Rewrites every task line into the panel's checkbox markup.
+ * Each task state's pattern and the markup it becomes, built once.
  *
  * The square carries the shared classes, so one CSS rule reaches the panel and
  * the editor at once, and the state's long-standing class, which the panel's
  * own script reads on a click. The text after the marker keeps its own class,
  * since the panel dims and strikes through a whole line where the editor only
  * colours the marker.
+ */
+const CHECKBOX_MARKUP = CHECKBOX_STATES.map(state => {
+  const legacy = LEGACY_CHECKBOX_CLASS[state.key];
+  return {
+    regex: checkboxLineRegex(state),
+    replacement: `$1- <span class="${checkboxClasses(state, 'itags-search-checkbox')} ${legacy}" ` +
+      `data-checked="${state.key === 'done'}"></span>` +
+      `<span class="itags-search-${legacy}">$2</span>\n`,
+  };
+});
+
+/**
+ * Rewrites every task line into the panel's checkbox markup.
  *
  * @param text The result text, before Markdown rendering
  */
 export function renderCheckboxes(text: string): string {
-  for (const state of CHECKBOX_STATES) {
-    const legacy = LEGACY_CHECKBOX_CLASS[state.key];
-    text = text.replace(checkboxLineRegex(state),
-      `$1- <span class="${checkboxClasses(state, 'itags-search-checkbox')} ${legacy}" ` +
-      `data-checked="${state.key === 'done'}"></span>` +
-      `<span class="itags-search-${legacy}">$2</span>\n`);
+  for (const { regex, replacement } of CHECKBOX_MARKUP) {
+    text = text.replace(regex, replacement);
   }
   return text;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -457,7 +457,8 @@ export async function registerSettings(): Promise<void> {
       label: 'Inline checkboxes: Highlight in editor',
       description: 'Colour the six task states - [ ] [@] [?] [!] [x] [~] - in the Markdown editor. ' +
         'Joplin renders [ ] and [x] as checkboxes of its own, so those two are unaffected while ' +
-        'its Render markup in editor setting is on. Requires restart',
+        'its Render markup in editor setting is on. The README has CSS that draws those two as ' +
+        'text markers too, if you want all six to match. Requires restart',
       options: {
         off: 'Off',
         markers: 'Text markers',
@@ -782,7 +783,7 @@ export async function registerSettings(): Promise<void> {
       advanced: true,
       label: 'Search: Panel style',
       description: 'Custom CSS for the search panel (toggle panel or restart app). ' +
-        'For tag appearance see Inline tags: Style.',
+        'For tag and checkbox appearance see Inline tags and checkboxes: Style.',
     },
     'itags.tagStyle': {
       value: '',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -448,6 +448,21 @@ export async function registerSettings(): Promise<void> {
       label: 'Inline tags: Highlight in editor',
       description: 'Requires restart',
     },
+    'itags.highlightCheckboxes': {
+      value: 'markers',
+      type: SettingItemType.String,
+      section: 'itags',
+      public: true,
+      isEnum: true,
+      label: 'Inline checkboxes: Highlight in editor',
+      description: 'Colour the six task states - [ ] [@] [?] [!] [x] [~] - in the Markdown editor. ' +
+        'Joplin renders [ ] and [x] as checkboxes of its own, so those two are unaffected while ' +
+        'its Render markup in editor setting is on. Requires restart',
+      options: {
+        off: 'Off',
+        markers: 'Text markers',
+      },
+    },
     'itags.renderFrontMatter': {
       value: true,
       type: SettingItemType.Bool,
@@ -775,10 +790,12 @@ export async function registerSettings(): Promise<void> {
       section: 'itags',
       public: true,
       advanced: true,
-      label: 'Inline tags: Style',
+      label: 'Inline tags and checkboxes: Style',
       description: 'Custom CSS for inline tags in the search panel (toggle panel or restart app), ' +
         'Markdown preview and editor. Target .itags-tag for all three, or ' +
         '.itags-tag--hash / --at / --plus / --slash for a specific prefix. ' +
+        'For checkbox markers target .itags-checkbox, or .itags-checkbox--open / --ongoing / ' +
+        '--in-question / --blocked / --done / --obsolete for one state. ' +
         'Also the only way to restyle tags on mobile.',
     },
     'itags.periodicConversion': {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -792,11 +792,9 @@ export async function registerSettings(): Promise<void> {
       public: true,
       advanced: true,
       label: 'Inline tags and checkboxes: Style',
-      description: 'Custom CSS for inline tags in the search panel (toggle panel or restart app), ' +
-        'Markdown preview and editor. Target .itags-tag for all three, or ' +
-        '.itags-tag--hash / --at / --plus / --slash for a specific prefix. ' +
-        'For checkbox markers target .itags-checkbox, or .itags-checkbox--open / --ongoing / ' +
-        '--in-question / --blocked / --done / --obsolete for one state. ' +
+      description: 'Custom CSS for inline tags and checkbox markers in the search panel ' +
+        '(toggle panel or restart app), Markdown preview and editor. Target .itags-tag and ' +
+        '.itags-checkbox; the README lists the per-prefix and per-state classes. ' +
         'Also the only way to restyle tags on mobile.',
     },
     'itags.periodicConversion': {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,3 +205,127 @@ export function tagBounds(matchText: string): { tag: string; lead: number } {
   const tag = matchText.trim();
   return { tag, lead: tag ? matchText.indexOf(tag) : 0 };
 }
+
+/**
+ * Class applied to every rendered checkbox marker, on every surface. The
+ * counterpart of SHARED_TAG_CLASS: one CSS rule can colour task states in the
+ * search panel and the editor at once, without the reader having to know which
+ * surface paints a square and which paints the [x] text.
+ */
+const SHARED_CHECKBOX_CLASS = 'itags-checkbox';
+
+/** One of the task states the plugin recognises, in inline [x]it! notation. */
+export type CheckboxState = {
+  /** Class suffix, and the stable identifier used across surfaces. */
+  key: string;
+  /** The characters that may appear between the brackets. Done takes both cases. */
+  markers: string[];
+  /** Default colour, shared by every surface that paints this state. */
+  colour: string;
+};
+
+/**
+ * The six task states, in the order the kanban board lays them out.
+ *
+ * One definition behind the panel's markup, the editor's highlighting and the
+ * default colours of both. The colours are the ones searchPanelStyle.css has
+ * always used, so the two surfaces agree by construction.
+ */
+export const CHECKBOX_STATES: CheckboxState[] = [
+  { key: 'open', markers: [' '], colour: '#4178be' },
+  { key: 'ongoing', markers: ['@'], colour: '#cb55c2' },
+  { key: 'in-question', markers: ['?'], colour: '#cc913f' },
+  { key: 'blocked', markers: ['!'], colour: '#e22d2d' },
+  { key: 'done', markers: ['x', 'X'], colour: '#64a073' },
+  { key: 'obsolete', markers: ['~'], colour: '#999999' },
+];
+
+/**
+ * The state a bracket character stands for, or null when it stands for none.
+ *
+ * @param marker The single character between the brackets
+ */
+export function checkboxStateFor(marker: string): CheckboxState | null {
+  return CHECKBOX_STATES.find(state => state.markers.includes(marker)) ?? null;
+}
+
+/**
+ * The full class list for a rendered checkbox marker.
+ *
+ * The same contract as tagClasses: shared classes for styling every surface at
+ * once, the surface's own classes for targeting one, each in a bare and a
+ * per-state form:
+ *
+ *   itags-checkbox  itags-checkbox--done  itags-editor-checkbox  itags-editor-checkbox--done
+ *
+ * @param state The task state the marker is in
+ * @param surfaceClass The surface's own base class
+ */
+export function checkboxClasses(state: CheckboxState, surfaceClass: string): string {
+  return `${SHARED_CHECKBOX_CLASS} ${SHARED_CHECKBOX_CLASS}--${state.key} ${surfaceClass} ${surfaceClass}--${state.key}`;
+}
+
+/** Escapes a marker for use inside a regex character class. */
+function escapeInClass(marker: string): string {
+  return marker.replace(/[\\\]^-]/g, '\\$&');
+}
+
+/** Escapes a marker for use on its own in a regex. escapeRegex() trims, which would drop the space of an open task. */
+function escapeMarker(marker: string): string {
+  return marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Matches a checkbox marker at the head of a list item, capturing the bracket
+ * character. A fresh instance per call, because MatchDecorator mutates
+ * lastIndex.
+ *
+ * Anchored at the start of the line and stopping at the closing bracket, so
+ * only "[x]" is decorated. The list marker is left alone: Joplin replaces the
+ * bullet of a list item with a widget of its own whenever markup rendering is
+ * on, which is the default, and a decoration spanning it would paint half a
+ * range that is no longer there.
+ */
+export function checkboxMarkerRegex(): RegExp {
+  const markers = CHECKBOX_STATES.map(state => state.markers.map(escapeInClass).join('')).join('');
+  return new RegExp(`^[ \\t]*[-*+][ \\t]+\\[([${markers}])\\](?=[ \\t]|$)`, 'g');
+}
+
+/**
+ * Matches whole lines in one task state, capturing the indent and the text
+ * after the marker. The form the search panel rewrites into HTML.
+ *
+ * @param state The task state to match
+ */
+export function checkboxLineRegex(state: CheckboxState): RegExp {
+  const marker = state.markers.length === 1
+    ? escapeMarker(state.markers[0])
+    : `[${state.markers.map(escapeInClass).join('')}]`;
+  return new RegExp(`(^[\\s]*)- \\[${marker}\\] (.*)$`, 'gm');
+}
+
+/**
+ * Default checkbox styling for one surface, as a cascade layer.
+ *
+ * Layered on the same terms as defaultTagCss, so the `Inline tags: Style`
+ * setting and userstyle.css override it without !important. Monospace and bold
+ * keep the marker legible at text size, which is what the states looked like
+ * under Rich Markdown's overlays.
+ *
+ * @param surfaceClass The surface's own base class
+ */
+export function defaultCheckboxCss(surfaceClass: string): string {
+  const colours = CHECKBOX_STATES.map(state =>
+    `  .${surfaceClass}--${state.key} {
+    color: ${state.colour};
+  }`).join('\n');
+
+  return `@layer itagsDefaults;
+@layer itagsDefaults {
+  .${surfaceClass} {
+    font-family: monospace;
+    font-weight: bold;
+  }
+${colours}
+}`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -305,12 +305,21 @@ export function checkboxLineRegex(state: CheckboxState): RegExp {
 }
 
 /**
- * Default checkbox styling for one surface, as a cascade layer.
+ * Default checkbox styling for one surface, as a cascade layer plus one
+ * unlayered rule.
  *
- * Layered on the same terms as defaultTagCss, so the `Inline tags: Style`
- * setting and userstyle.css override it without !important. Monospace and bold
- * keep the marker legible at text size, which is what the states looked like
- * under Rich Markdown's overlays.
+ * The colours are layered on the same terms as defaultTagCss, so the
+ * `Inline tags and checkboxes: Style` setting and userstyle.css override them
+ * without !important. Monospace and bold keep the marker legible at text size,
+ * which is what the states looked like under Rich Markdown's overlays.
+ *
+ * The last rule cannot be layered. In the editor a marker is a token of its
+ * own: Joplin's Markdown parser reads [@] as a link and its theme styles links
+ * and list content, so the marker text sits in a span inside the decoration
+ * carrying a colour and a font of its own. That span would keep them whatever
+ * the decoration says, because an unlayered rule beats a layered one at any
+ * specificity. Making it inherit hands both back to the decoration, and so to
+ * whoever styles it, rather than fixing a colour and a font here.
  *
  * @param surfaceClass The surface's own base class
  */
@@ -327,5 +336,10 @@ export function defaultCheckboxCss(surfaceClass: string): string {
     font-weight: bold;
   }
 ${colours}
+}
+.${surfaceClass} * {
+  color: inherit;
+  font-family: inherit;
+  font-weight: inherit;
 }`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -313,13 +313,22 @@ export function checkboxLineRegex(state: CheckboxState): RegExp {
  * without !important. Monospace and bold keep the marker legible at text size,
  * which is what the states looked like under Rich Markdown's overlays.
  *
- * The last rule cannot be layered. In the editor a marker is a token of its
- * own: Joplin's Markdown parser reads [@] as a link and its theme styles links
- * and list content, so the marker text sits in a span inside the decoration
- * carrying a colour and a font of its own. That span would keep them whatever
- * the decoration says, because an unlayered rule beats a layered one at any
- * specificity. Making it inherit hands both back to the decoration, and so to
- * whoever styles it, rather than fixing a colour and a font here.
+ * The last two rules cannot be layered, because Joplin's editor theme is not.
+ * A layered rule loses to an unlayered one at any specificity, so:
+ *
+ * - The font leads with `span` to clear `.<theme> span { font-family: inherit }`,
+ *   which Joplin's theme applies to every span in the editor and which
+ *   outranks a bare class. Ours ties on specificity and wins on order, since
+ *   CodeMirror mounts its theme at the top of the head and this is appended.
+ * - A marker is also a token of its own: Joplin reads [@] as a link and styles
+ *   links and list content, so the marker text sits in a span inside the
+ *   decoration carrying a colour and a font of its own. Making that span
+ *   inherit hands both back to the decoration, and so to whoever styles it,
+ *   rather than fixing a colour and a font here.
+ *
+ * The colours stay layered: nothing in the editor sets a colour on every span,
+ * so there is nothing to outrank, and the layer keeps them overridable by a
+ * plain class selector.
  *
  * @param surfaceClass The surface's own base class
  */
@@ -331,13 +340,13 @@ export function defaultCheckboxCss(surfaceClass: string): string {
 
   return `@layer itagsDefaults;
 @layer itagsDefaults {
-  .${surfaceClass} {
-    font-family: monospace;
-    font-weight: bold;
-  }
 ${colours}
 }
-.${surfaceClass} * {
+span.${surfaceClass} {
+  font-family: monospace;
+  font-weight: bold;
+}
+span.${surfaceClass} * {
   color: inherit;
   font-family: inherit;
   font-weight: inherit;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -281,7 +281,9 @@ function escapeMarker(marker: string): string {
  * lastIndex.
  *
  * Anchored at the start of the line and stopping at the closing bracket, so
- * only "[x]" is decorated. The list marker is left alone: Joplin replaces the
+ * only "[x]" is decorated. `^` needs no `m` flag: MatchDecorator runs the
+ * pattern over one line of text at a time (iterMatches in @codemirror/view
+ * skips line breaks), so it already anchors to a line. The list marker is left alone: Joplin replaces the
  * bullet of a list item with a widget of its own whenever markup rendering is
  * on, which is the default, and a decoration spanning it would paint half a
  * range that is no longer there.
@@ -305,8 +307,8 @@ export function checkboxLineRegex(state: CheckboxState): RegExp {
 }
 
 /**
- * Default checkbox styling for one surface, as a cascade layer plus one
- * unlayered rule.
+ * Default checkbox styling for one surface, as a cascade layer plus two
+ * unlayered rules.
  *
  * The colours are layered on the same terms as defaultTagCss, so the
  * `Inline tags and checkboxes: Style` setting and userstyle.css override them

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -265,12 +265,19 @@ export function checkboxClasses(state: CheckboxState, surfaceClass: string): str
   return `${SHARED_CHECKBOX_CLASS} ${SHARED_CHECKBOX_CLASS}--${state.key} ${surfaceClass} ${surfaceClass}--${state.key}`;
 }
 
-/** Escapes a marker for use inside a regex character class. */
+/**
+ * Escapes a marker for a character class, [ x@], where only these four
+ * characters are special. Use escapeMarker for one standing on its own.
+ */
 function escapeInClass(marker: string): string {
   return marker.replace(/[\\\]^-]/g, '\\$&');
 }
 
-/** Escapes a marker for use on its own in a regex. escapeRegex() trims, which would drop the space of an open task. */
+/**
+ * Escapes a marker standing on its own in a pattern. Use escapeInClass inside
+ * a character class, where a different set of characters is special, and not
+ * escapeRegex, which trims and so would drop the space of an open task.
+ */
 function escapeMarker(marker: string): string {
   return marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/checkboxStyle.test.ts
+++ b/tests/checkboxStyle.test.ts
@@ -131,6 +131,9 @@ describe('checkboxMarkerRegex', () => {
   });
 });
 
+/** Everything after the cascade layer, which is where the editor's rules go. */
+const unlayered = (css: string) => css.slice(css.indexOf('\n}\n') + 3);
+
 describe('defaultCheckboxCss', () => {
   const css = defaultCheckboxCss('itags-editor-checkbox');
 
@@ -145,20 +148,35 @@ describe('defaultCheckboxCss', () => {
     }
   });
 
+  test('sets the font outside the layer, and specifically enough for Joplin', () => {
+    // Joplin's editor theme carries `.<theme> span { font-family: inherit }`,
+    // which applies to the decoration itself and outranks a bare class, and
+    // being unlayered it beats a layered rule at any specificity. Leading with
+    // `span` ties on specificity, and our style element is appended after
+    // CodeMirror's, so it wins on order. Verified in Chromium against Joplin's
+    // own generated CSS: without the `span` the marker renders in the editor
+    // font, with it in monospace.
+    expect(unlayered(css)).toContain('span.itags-editor-checkbox {');
+    expect(unlayered(css)).toContain('font-family: monospace;');
+  });
+
   test('hands the colour and font of a nested token span back to the decoration', () => {
     // Joplin reads [@] as a link and its theme styles links and list content,
     // so the marker text sits in a span of its own inside the decoration. That
     // span keeps its colour and font unless a rule outside the layer says
-    // otherwise, since an unlayered rule beats a layered one at any
-    // specificity. Verified in Chromium: without this rule the marker keeps
-    // the token's colour and font, with it the marker takes the state colour,
-    // the monospace default, and any override of them.
-    const [layered, unlayered] = css.split('\n}\n');
+    // otherwise. Making it inherit hands both back to the decoration, and so
+    // to whoever styles it.
+    expect(unlayered(css)).toContain('span.itags-editor-checkbox * {');
+    expect(unlayered(css)).toContain('color: inherit;');
+    expect(unlayered(css)).toContain('font-family: inherit;');
+    expect(unlayered(css)).toContain('font-weight: inherit;');
+  });
+
+  test('keeps the colours in the layer, where a plain class overrides them', () => {
+    const layered = css.slice(0, css.indexOf('\n}\n'));
     expect(layered).toContain('@layer itagsDefaults {');
-    expect(unlayered).toContain('.itags-editor-checkbox * {');
-    expect(unlayered).toContain('color: inherit;');
-    expect(unlayered).toContain('font-family: inherit;');
-    expect(unlayered).toContain('font-weight: inherit;');
+    expect(layered).toContain('color: #cb55c2;');
+    expect(unlayered(css)).not.toContain('#cb55c2');
   });
 
   test('names the surface it was asked for', () => {

--- a/tests/checkboxStyle.test.ts
+++ b/tests/checkboxStyle.test.ts
@@ -1,0 +1,151 @@
+import {
+  CHECKBOX_STATES,
+  checkboxClasses,
+  checkboxLineRegex,
+  checkboxMarkerRegex,
+  checkboxStateFor,
+  defaultCheckboxCss,
+} from '../src/utils';
+
+/**
+ * The panel's six regexes as they stood before CHECKBOX_STATES existed. The
+ * generated ones must be identical to these, or the panel's rendered HTML
+ * changes under it.
+ */
+const PANEL_REGEXES: Record<string, RegExp> = {
+  'open': /(^[\s]*)- \[ \] (.*)$/gm,
+  'done': /(^[\s]*)- \[[xX]\] (.*)$/gm,
+  'ongoing': /(^[\s]*)- \[@\] (.*)$/gm,
+  'obsolete': /(^[\s]*)- \[~\] (.*)$/gm,
+  'in-question': /(^[\s]*)- \[\?\] (.*)$/gm,
+  'blocked': /(^[\s]*)- \[!\] (.*)$/gm,
+};
+
+describe('checkbox state model', () => {
+  test('covers the six states the kanban board lays out, in its order', () => {
+    expect(CHECKBOX_STATES.map(state => state.key)).toEqual([
+      'open', 'ongoing', 'in-question', 'blocked', 'done', 'obsolete',
+    ]);
+  });
+
+  test('maps every bracket character to its state', () => {
+    expect(checkboxStateFor(' ')?.key).toBe('open');
+    expect(checkboxStateFor('@')?.key).toBe('ongoing');
+    expect(checkboxStateFor('?')?.key).toBe('in-question');
+    expect(checkboxStateFor('!')?.key).toBe('blocked');
+    expect(checkboxStateFor('x')?.key).toBe('done');
+    expect(checkboxStateFor('X')?.key).toBe('done');
+    expect(checkboxStateFor('~')?.key).toBe('obsolete');
+  });
+
+  test('keeps the colours searchPanelStyle.css paints the same states with', () => {
+    // Asserted as literals, not read from the map: the panel's stylesheet holds
+    // its own copy, and the two are only in step while these values hold.
+    expect(CHECKBOX_STATES.map(state => state.colour)).toEqual([
+      '#4178be', '#cb55c2', '#cc913f', '#e22d2d', '#64a073', '#999999',
+    ]);
+  });
+
+  test('maps an unknown character to no state', () => {
+    expect(checkboxStateFor('y')).toBeNull();
+    expect(checkboxStateFor('')).toBeNull();
+  });
+});
+
+describe('checkboxClasses', () => {
+  test('carries the shared and surface classes, bare and per state', () => {
+    const done = CHECKBOX_STATES.find(state => state.key === 'done');
+    expect(checkboxClasses(done, 'itags-editor-checkbox')).toBe(
+      'itags-checkbox itags-checkbox--done itags-editor-checkbox itags-editor-checkbox--done');
+  });
+
+  test('names the same shared class on every surface', () => {
+    const open = CHECKBOX_STATES.find(state => state.key === 'open');
+    for (const surface of ['itags-editor-checkbox', 'itags-search-checkbox']) {
+      expect(checkboxClasses(open, surface).split(' ')).toContain('itags-checkbox--open');
+    }
+  });
+});
+
+describe('checkboxLineRegex', () => {
+  test('reproduces the panel regexes exactly', () => {
+    for (const state of CHECKBOX_STATES) {
+      const generated = checkboxLineRegex(state);
+      expect(generated.source).toBe(PANEL_REGEXES[state.key].source);
+      expect(generated.flags).toBe(PANEL_REGEXES[state.key].flags);
+    }
+  });
+
+  test('captures the indent and the text after the marker', () => {
+    const ongoing = CHECKBOX_STATES.find(state => state.key === 'ongoing');
+    const match = checkboxLineRegex(ongoing).exec('  - [@] write the plan');
+    expect(match[1]).toBe('  ');
+    expect(match[2]).toBe('write the plan');
+  });
+});
+
+describe('checkboxMarkerRegex', () => {
+  const matchAll = (line: string) => Array.from(line.matchAll(checkboxMarkerRegex()));
+
+  test('matches every state at the head of a list item', () => {
+    for (const marker of [' ', '@', '?', '!', 'x', 'X', '~']) {
+      const matches = matchAll(`- [${marker}] task`);
+      expect(matches).toHaveLength(1);
+      expect(matches[0][0]).toBe(`- [${marker}]`);
+      expect(matches[0][1]).toBe(marker);
+    }
+  });
+
+  test('matches under any list marker and any indent', () => {
+    expect(matchAll('* [@] task')).toHaveLength(1);
+    expect(matchAll('+ [@] task')).toHaveLength(1);
+    expect(matchAll('    - [@] task')).toHaveLength(1);
+    expect(matchAll('\t- [@] task')).toHaveLength(1);
+  });
+
+  test('matches a marker with nothing after it', () => {
+    expect(matchAll('- [@]')).toHaveLength(1);
+  });
+
+  test('ignores brackets that are not a list marker', () => {
+    expect(matchAll('see [x] below')).toHaveLength(0);
+    expect(matchAll('-[x] no space')).toHaveLength(0);
+    expect(matchAll('- [y] unknown state')).toHaveLength(0);
+    expect(matchAll('- [xx] two characters')).toHaveLength(0);
+    expect(matchAll('1. [x] ordered')).toHaveLength(0);
+  });
+
+  test('does not match a marker glued to the text', () => {
+    expect(matchAll('- [x]task')).toHaveLength(0);
+  });
+
+  test('anchors on the brackets, not the list marker', () => {
+    const [match] = matchAll('  - [x] done');
+    expect(match.index + match[0].indexOf('[')).toBe(4);
+  });
+
+  test('returns a fresh instance, since MatchDecorator mutates lastIndex', () => {
+    const first = checkboxMarkerRegex();
+    first.lastIndex = 3;
+    expect(checkboxMarkerRegex().lastIndex).toBe(0);
+  });
+});
+
+describe('defaultCheckboxCss', () => {
+  const css = defaultCheckboxCss('itags-editor-checkbox');
+
+  test('is layered, so unlayered user CSS overrides it', () => {
+    expect(css).toContain('@layer itagsDefaults');
+  });
+
+  test('gives every state its colour', () => {
+    for (const state of CHECKBOX_STATES) {
+      expect(css).toContain(`.itags-editor-checkbox--${state.key} {`);
+      expect(css).toContain(state.colour);
+    }
+  });
+
+  test('names the surface it was asked for', () => {
+    expect(defaultCheckboxCss('itags-search-checkbox')).toContain('.itags-search-checkbox--done');
+  });
+});

--- a/tests/checkboxStyle.test.ts
+++ b/tests/checkboxStyle.test.ts
@@ -145,6 +145,22 @@ describe('defaultCheckboxCss', () => {
     }
   });
 
+  test('hands the colour and font of a nested token span back to the decoration', () => {
+    // Joplin reads [@] as a link and its theme styles links and list content,
+    // so the marker text sits in a span of its own inside the decoration. That
+    // span keeps its colour and font unless a rule outside the layer says
+    // otherwise, since an unlayered rule beats a layered one at any
+    // specificity. Verified in Chromium: without this rule the marker keeps
+    // the token's colour and font, with it the marker takes the state colour,
+    // the monospace default, and any override of them.
+    const [layered, unlayered] = css.split('\n}\n');
+    expect(layered).toContain('@layer itagsDefaults {');
+    expect(unlayered).toContain('.itags-editor-checkbox * {');
+    expect(unlayered).toContain('color: inherit;');
+    expect(unlayered).toContain('font-family: inherit;');
+    expect(unlayered).toContain('font-weight: inherit;');
+  });
+
   test('names the surface it was asked for', () => {
     expect(defaultCheckboxCss('itags-search-checkbox')).toContain('.itags-search-checkbox--done');
   });

--- a/tests/editorCheckboxStyle.test.ts
+++ b/tests/editorCheckboxStyle.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the editor checkbox highlighting.
+ *
+ * checkboxMarker is the arithmetic that decides which characters get painted.
+ * It must stop at the brackets: Joplin replaces the bullet of a list item with
+ * a widget of its own whenever `Render markup in editor` is on, which is the
+ * default, so a decoration spanning the bullet paints a range that is no
+ * longer there.
+ *
+ * The code-context tests are the ones with history. Indented blocks reading as
+ * code cost the indexer five junk tags from one pasted snippet (#51), and the
+ * editor answers that question from the syntax tree rather than by counting
+ * columns, so each form is asserted against a real parse.
+ */
+import { checkboxMarker, inCodeContext } from '../src/cm6tagStyle';
+import { EditorState } from '@codemirror/state';
+import { markdown } from '@codemirror/lang-markdown';
+import { checkboxMarkerRegex } from '../src/utils';
+
+/** The first match of the editor's checkbox pattern in a line. */
+const matchIn = (line: string): RegExpExecArray => checkboxMarkerRegex().exec(line);
+
+/** A state parsed as Markdown, the way the editor parses it. */
+const stateOf = (doc: string) => EditorState.create({ doc, extensions: [markdown()] });
+
+describe('checkboxMarker', () => {
+  test('paints the brackets and nothing before them', () => {
+    const marker = checkboxMarker(matchIn('- [x] done'));
+    expect(marker.start).toBe(2);
+    expect(marker.end).toBe(5);
+  });
+
+  test('keeps the bullet out of the range at any indent', () => {
+    for (const line of ['  - [@] task', '\t\t* [@] task', '   + [@] task']) {
+      const marker = checkboxMarker(matchIn(line));
+      expect(line.slice(marker.start, marker.end)).toBe('[@]');
+    }
+  });
+
+  test('names the state on both the shared and the editor class', () => {
+    const marker = checkboxMarker(matchIn('- [~] dropped'));
+    expect(marker.className.split(' ')).toEqual([
+      'itags-checkbox', 'itags-checkbox--obsolete',
+      'itags-editor-checkbox', 'itags-editor-checkbox--obsolete',
+    ]);
+  });
+
+  test('gives both cases of done the same class', () => {
+    expect(checkboxMarker(matchIn('- [X] done')).className)
+      .toBe(checkboxMarker(matchIn('- [x] done')).className);
+  });
+
+  test('paints nothing for a character that is not a state', () => {
+    // Not reachable through the shared pattern, which only matches the six.
+    const invented = Object.assign(['- [y]', 'y'], { index: 0, input: '- [y]' }) as unknown as RegExpExecArray;
+    expect(checkboxMarker(invented)).toBeNull();
+  });
+});
+
+describe('checkboxes in code', () => {
+  /** Whether the marker of the given line would be painted. */
+  const painted = (doc: string, line: string): boolean => {
+    const lineStart = doc.indexOf(line);
+    const marker = checkboxMarker(matchIn(line));
+    return !inCodeContext(stateOf(doc), lineStart + marker.start);
+  };
+
+  test('paints a task in ordinary text', () => {
+    expect(painted('notes\n\n- [@] task\n', '- [@] task')).toBe(true);
+  });
+
+  test('skips a task inside a fenced block', () => {
+    expect(painted('```\n- [@] task\n```\n', '- [@] task')).toBe(false);
+  });
+
+  test('skips a task inside an indented block', () => {
+    expect(painted('paste:\n\n    - [@] task\n', '    - [@] task')).toBe(false);
+  });
+
+  test('skips a task inside a tab-indented block', () => {
+    expect(painted('paste:\n\n\t- [@] task\n', '\t- [@] task')).toBe(false);
+  });
+
+  test('paints a task nested in a list, which is not code', () => {
+    expect(painted('- outer\n    - [@] task\n', '    - [@] task')).toBe(true);
+  });
+
+  test('skips a task inside an inline code span', () => {
+    const doc = 'see `- [@] task` here';
+    expect(inCodeContext(stateOf(doc), doc.indexOf('[@]'))).toBe(true);
+  });
+});

--- a/tests/panelCheckboxes.test.ts
+++ b/tests/panelCheckboxes.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the search panel's checkbox markup.
+ *
+ * The panel's six replacements now come from CHECKBOX_STATES rather than six
+ * literals. What the panel emits is read back by its own script (a click on
+ * .itags-search-checkbox, the state from .xitOpen and friends) and by whatever
+ * CSS users have written against those names, so the markup is asserted whole,
+ * not by substring.
+ */
+import { renderCheckboxes } from '../src/searchPanel';
+
+/**
+ * The markup each state must emit: the classes the panel has always used, plus
+ * the shared ones. Written out in full rather than assembled from the same
+ * helpers the code uses, so a change to either has to be made here too.
+ */
+const EXPECTED: Record<string, string> = {
+  ' ': '- <span class="itags-checkbox itags-checkbox--open itags-search-checkbox itags-search-checkbox--open xitOpen" data-checked="false"></span><span class="itags-search-xitOpen">task</span>',
+  '@': '- <span class="itags-checkbox itags-checkbox--ongoing itags-search-checkbox itags-search-checkbox--ongoing xitOngoing" data-checked="false"></span><span class="itags-search-xitOngoing">task</span>',
+  '?': '- <span class="itags-checkbox itags-checkbox--in-question itags-search-checkbox itags-search-checkbox--in-question xitInQuestion" data-checked="false"></span><span class="itags-search-xitInQuestion">task</span>',
+  '!': '- <span class="itags-checkbox itags-checkbox--blocked itags-search-checkbox itags-search-checkbox--blocked xitBlocked" data-checked="false"></span><span class="itags-search-xitBlocked">task</span>',
+  'x': '- <span class="itags-checkbox itags-checkbox--done itags-search-checkbox itags-search-checkbox--done xitDone" data-checked="true"></span><span class="itags-search-xitDone">task</span>',
+  'X': '- <span class="itags-checkbox itags-checkbox--done itags-search-checkbox itags-search-checkbox--done xitDone" data-checked="true"></span><span class="itags-search-xitDone">task</span>',
+  '~': '- <span class="itags-checkbox itags-checkbox--obsolete itags-search-checkbox itags-search-checkbox--obsolete xitObsolete" data-checked="false"></span><span class="itags-search-xitObsolete">task</span>',
+};
+
+describe('renderCheckboxes', () => {
+  test('emits the markup for every state, old classes included', () => {
+    for (const [marker, expected] of Object.entries(EXPECTED)) {
+      expect(renderCheckboxes(`- [${marker}] task`)).toBe(`${expected}\n`);
+    }
+  });
+
+  test('keeps the indent and the text after the marker', () => {
+    const rendered = renderCheckboxes('    - [~] drop this');
+    expect(rendered.startsWith('    - <span')).toBe(true);
+    expect(rendered).toContain('<span class="itags-search-xitObsolete">drop this</span>');
+  });
+
+  test('rewrites every task in a block, and nothing else', () => {
+    const rendered = renderCheckboxes('# heading\n- [ ] one\ntext\n- [x] two\n- [y] not a state');
+    expect(rendered).toContain('# heading');
+    expect(rendered).toContain('text');
+    expect(rendered).toContain('- [y] not a state');
+    expect(rendered.match(/itags-search-checkbox /g)).toHaveLength(2);
+  });
+
+  test('leaves a marker without a trailing space alone, as the panel always has', () => {
+    expect(renderCheckboxes('- [@]')).toBe('- [@]');
+  });
+});


### PR DESCRIPTION
## What

The six [x]it! task states styled in the Markdown editor, from the same definition the search panel paints them with, plus a class contract that reaches the panel and the editor at once.

New setting, `Inline checkboxes: Highlight in editor`, off or text markers, defaulting to text markers.

## Why

Rich Markdown's regex overlays used to do this. v2.11.0 replaced its tag styling and left the checkbox half behind. The plugin already owns the six-state model end to end (`CHECKBOX_STATE_ORDER`, the panel's colours, the six-state context menu, kanban grouping), and the editor was the one surface that knew about the states and showed nothing.

Joplin will not fill the gap: `@lezer/markdown`'s TaskList only recognises `[ ]`, `[x]` and `[X]` (`dist/index.cjs:2187`), so `[@]`, `[?]`, `[!]` and `[~]` produce no `TaskMarker` node, no widget and no styling. Those four are what this makes visible. The two Joplin does recognise it renders as checkboxes of its own, and they are left alone.

## How

- `CHECKBOX_STATES` in `utils.ts` is now the one definition of the states, their bracket characters and their colours (the ones `searchPanelStyle.css` has always used). The panel's six regexes and the editor's single pattern are generated from it, and the tests pin the generated regexes to the six literals `searchPanel.ts` held.
- `markerPlugin(regexp, locate)` in the content script owns the MatchDecorator, the rebuild-on-tree-change branch and the code-context skip. Tags became one caller; checkboxes are the second, costing a pattern and a function that says where in a match to paint.
- The decoration covers the brackets only. Joplin replaces a list bullet with a widget of its own when rendering is on, so a decoration spanning `- [@]` would paint a range that is no longer there.
- `checkboxClasses` follows the `tagClasses` contract: `itags-checkbox itags-checkbox--done itags-editor-checkbox itags-editor-checkbox--done`. The panel's squares carry the shared classes alongside the `xitDone` names its own script reads on a click, so nobody's CSS breaks. Its six near-identical replacements became one pass over the shared states.

### The cascade, which is most of the review surface here

The first working version painted nothing, and the reason generalises. `@lezer/markdown` reads every `[x]` form as a Link, Joplin's theme colours links and gives list content a font (`theme.ts`, `tags.link` and `tags.list`), so the marker text sits in a token span **inside** the decoration carrying a colour and a font of its own. A layered rule can never answer that: an unlayered rule beats a layered one at any specificity, and Joplin's theme is unlayered.

So one unlayered rule makes that token span inherit, which hands colour and font back to the decoration and to whoever styles it, instead of pinning values outside the layer. The state colours stay layered and overridable without `!important`. The same trap waits for anything else we decorate over that Joplin's theme also styles.

## What was deliberately left out

An option to draw Joplin's rendered `[ ]` and `[x]` as text markers too, so that all six states match, was written and then removed. It worked, but it depended on the class name `.cm-ext-checkbox-toggle`, the widget being an `<input>` inside a span, `appearance: none` rendering `::after`, the theme's selector depth, CodeMirror mounting its theme at the top of `<head>`, and the bullet widget's structure for alignment. None of that is API, none of it can be tested in CI, and a rename would fail silently.

The CSS is documented in the README instead, in the collapsed examples, for anyone who wants that look. In a user's own style setting a Joplin change is two lines for them to fix; in the plugin it would be a silent regression.

## Testing

154 tests, and two harnesses for what unit tests cannot reach:

- Joplin's own editor stack under jsdom (its CodeMirror, its Markdown extensions, its rendering extension, `inlineRendering` on) running the built `dist/cm6tagStyle.js`, to see which spans the decoration actually produces.
- Headless Chromium over the generated CSS in a DOM shaped like the editor's, to judge the cascade: token span inside the decoration, Joplin's theme mounted at the top of `<head>` the way style-mod mounts it, ours appended last. Control runs confirm the marker keeps the link colour and font without the inherit rule.

## Known divergence, not fixed here

The editor highlights `* [@]`, `+ [@]` and a bare `- [@]` at end of line; the panel and kanban recognise `- ` only and require a trailing space. The panel is the narrow one, and widening it changes what the panel renders and what the board groups, so it stays out of this change. Both behaviours are pinned by tests.
